### PR TITLE
Added OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- mmorhun
+- psturc
+- Michkov
+
+reviewers:
+- mmorhun
+- psturc
+- Michkov
+


### PR DESCRIPTION
OWNERS file is being used by openshift-ci and the on boarding PR check failed with [error](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/38199/pull-ci-openshift-release-master-owners/1645662925639127040)