### PR TITLE
feat: Handle robot account longname in quay

### DIFF
--- a/pkg/quay/quay.go
+++ b/pkg/quay/quay.go
@@ -385,6 +385,7 @@ func (c *QuayClient) GetAllRobotAccounts(organization string) ([]RobotAccount, e
 func handleRobotName(robotName string) (string, error) {
 	// Regexp from quay api `^([a-z0-9]+(?:[._-][a-z0-9]+)*)$` with one plus sign in the middle allowed (representing longname)
 	r, err := regexp.Compile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:\+[a-z0-9]+(?:[._-][a-z0-9]+)*)?$`)
+	robotName = strings.TrimSpace(robotName)
 	if err != nil {
 		return "", fmt.Errorf("failed to compile regex, error: %s", err)
 	}

--- a/pkg/quay/quay.go
+++ b/pkg/quay/quay.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -380,11 +381,20 @@ func (c *QuayClient) GetAllRobotAccounts(organization string) ([]RobotAccount, e
 }
 
 // If robotName is in longform, return shortname
+// e.g. `org+robot` will be changed to `robot`, `robot` will stay `robot`
 func handleRobotName(robotName string) (string, error) {
+	// Regexp from quay api `^([a-z0-9]+(?:[._-][a-z0-9]+)*)$` with one plus sign in the middle allowed (representing longname)
+	r, err := regexp.Compile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:\+[a-z0-9]+(?:[._-][a-z0-9]+)*)?$`)
+	if err != nil {
+		return "", fmt.Errorf("failed to compile regex, error: %s", err)
+	}
+	if !r.MatchString(robotName) {
+		return "", fmt.Errorf("robot name is invalid, must match `^([a-z0-9]+(?:[._-][a-z0-9]+)*)$` (one plus sign in the middle is also allowed)")
+	}
 	if strings.Contains(robotName, "+") {
 		parts := strings.Split(robotName, "+")
 		if len(parts) != 2 {
-			return robotName, fmt.Errorf("robotName could not be split into two parts, expected len 2, got len %d", len(parts))
+			return "", fmt.Errorf("robotName could not be split into two parts, expected len 2, got len %d", len(parts))
 		}
 		robotName = parts[1]
 	}

--- a/pkg/quay/quay_test.go
+++ b/pkg/quay/quay_test.go
@@ -191,4 +191,17 @@ func TestQuayClient_handleRobotName(t *testing.T) {
 	if shortName != longName {
 		t.Errorf("expected shortname `%s` to be the same as longname `%s`", shortName, longName)
 	}
+
+	_, err = handleRobotName("")
+	if err == nil {
+		t.Error("false match for empty string")
+	}
+	_, err = handleRobotName("org+second+test")
+	if err == nil {
+		t.Error("false match for two plus signs")
+	}
+	_, err = handleRobotName("+")
+	if err == nil {
+		t.Error("false match for `+`")
+	}
 }

--- a/pkg/quay/quay_test.go
+++ b/pkg/quay/quay_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package quay
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -180,28 +182,83 @@ func TestQuayClient_GetAllRobotAccounts(t *testing.T) {
 }
 
 func TestQuayClient_handleRobotName(t *testing.T) {
-	shortName, err := handleRobotName("robot")
-	if err != nil {
-		t.Errorf("error handling shortname, got: %s", err)
+	invalidRobotNameErr := fmt.Errorf("robot name is invalid, must match `^([a-z0-9]+(?:[._-][a-z0-9]+)*)$` (one plus sign in the middle is also allowed)")
+	testCases := []struct {
+		name         string
+		input        string
+		expectedName string
+		expectedErr  error
+	}{
+		{
+			name:         "valid short name",
+			input:        "robot",
+			expectedName: "robot",
+			expectedErr:  nil,
+		},
+		{
+			name:         "valid long name",
+			input:        "org+robot",
+			expectedName: "robot",
+			expectedErr:  nil,
+		},
+		{
+			name:         "empty input",
+			input:        "",
+			expectedName: "",
+			expectedErr:  invalidRobotNameErr,
+		},
+		{
+			name:         "two plus signs in name",
+			input:        "org+second+test",
+			expectedName: "",
+			expectedErr:  invalidRobotNameErr,
+		},
+		{
+			name:         "lone plus sign",
+			input:        "+",
+			expectedName: "",
+			expectedErr:  invalidRobotNameErr,
+		},
+		{
+			name:         "special character in name",
+			input:        "robot!robot",
+			expectedName: "",
+			expectedErr:  invalidRobotNameErr,
+		},
+		{
+			name:         "uppercase character in name",
+			input:        "RobOt",
+			expectedName: "",
+			expectedErr:  invalidRobotNameErr,
+		},
+		{
+			name:         "leading spaces in name",
+			input:        "  robot  ",
+			expectedName: "robot",
+			expectedErr:  nil,
+		},
+		{
+			name:         "non-alphanumeric character in name",
+			input:        "róbot",
+			expectedName: "",
+			expectedErr:  invalidRobotNameErr,
+		},
+		{
+			name:         "allowed characters in name",
+			input:        "robot_robot-robot.robot",
+			expectedName: "robot_robot-robot.robot",
+			expectedErr:  nil,
+		},
 	}
-	longName, err := handleRobotName("org+robot")
-	if err != nil {
-		t.Errorf("error handling longname, got: %s", err)
-	}
-	if shortName != longName {
-		t.Errorf("expected shortname `%s` to be the same as longname `%s`", shortName, longName)
-	}
-
-	_, err = handleRobotName("")
-	if err == nil {
-		t.Error("false match for empty string")
-	}
-	_, err = handleRobotName("org+second+test")
-	if err == nil {
-		t.Error("false match for two plus signs")
-	}
-	_, err = handleRobotName("+")
-	if err == nil {
-		t.Error("false match for `+`")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualName, actualErr := handleRobotName(tc.input)
+			if actualName != tc.expectedName {
+				t.Errorf("expected robot name `%s` but got `%s`", tc.expectedName, actualName)
+			}
+			if (actualErr != nil || tc.expectedErr != nil) && errors.Is(actualErr, tc.expectedErr) {
+				t.Errorf("expected error `%s`, but got `%s`", tc.expectedErr, actualErr)
+			}
+		})
 	}
 }

--- a/pkg/quay/quay_test.go
+++ b/pkg/quay/quay_test.go
@@ -178,3 +178,17 @@ func TestQuayClient_GetAllRobotAccounts(t *testing.T) {
 		t.Errorf("Error getting all robot accounts, Expected nil, got %v", err)
 	}
 }
+
+func TestQuayClient_handleRobotName(t *testing.T) {
+	shortName, err := handleRobotName("robot")
+	if err != nil {
+		t.Errorf("error handling shortname, got: %s", err)
+	}
+	longName, err := handleRobotName("org+robot")
+	if err != nil {
+		t.Errorf("error handling longname, got: %s", err)
+	}
+	if shortName != longName {
+		t.Errorf("expected shortname `%s` to be the same as longname `%s`", shortName, longName)
+	}
+}


### PR DESCRIPTION
`CreateRobotAccount` and `DeleteRobotAccount` may fail when accidentally using longform robot account name because [quay.io api](https://docs.quay.io/api/swagger) requires shortname. 
Added `handleRobotName` which will convert longname to shortname and leave shortname be.
e.g. `org+robot` will be changed to `robot`, `robot` will stay `robot`