### PR TITLE
Align log format according to ADR6

### DIFF
--- a/controllers/component_image_controller_remote_test.go
+++ b/controllers/component_image_controller_remote_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"testing"
@@ -24,7 +25,6 @@ import (
 	appstudioredhatcomv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/image-controller/pkg/quay"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func TestGenerateRemoteImage(t *testing.T) {
@@ -58,9 +58,8 @@ func TestGenerateRemoteImage(t *testing.T) {
 	r := ComponentReconciler{
 		QuayClient:       &quayClient,
 		QuayOrganization: "redhat-user-workloads",
-		Log:              ctrl.Log.WithName("TestGenerateImageRepository"),
 	}
-	createdRepository, createdRobotAccount, err := r.generateImageRepository(&testComponent)
+	createdRepository, createdRobotAccount, err := r.generateImageRepository(context.TODO(), &testComponent)
 
 	if err != nil {
 		t.Errorf("Error generating repository and setting up robot account, Expected nil, got %v", err)

--- a/controllers/component_image_controller_unit_test.go
+++ b/controllers/component_image_controller_unit_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,7 +27,6 @@ import (
 	"github.com/redhat-appstudio/image-controller/pkg/quay"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func TestShouldGenerateImage(t *testing.T) {
@@ -124,10 +124,8 @@ func TestGenerateImageRepository(t *testing.T) {
 	r := ComponentReconciler{
 		QuayClient:       &quayClient,
 		QuayOrganization: expectedNamespace,
-		Log:              ctrl.Log.WithName("TestGenerateImageRepository"),
 	}
-
-	createdRepository, createdRobotAccount, err := r.generateImageRepository(&testComponent)
+	createdRepository, createdRobotAccount, err := r.generateImageRepository(context.TODO(), &testComponent)
 
 	if err != nil {
 		t.Errorf("Error generating repository and setting up robot account, Expected nil, got %v", err)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -112,7 +112,6 @@ var _ = BeforeSuite(func() {
 	err = (&controllers.ComponentReconciler{
 		Client:           k8sManager.GetClient(),
 		Scheme:           k8sManager.GetScheme(),
-		Log:              ctrl.Log.WithName("controllers").WithName("ComponentImage"),
 		QuayClient:       &quayClient,
 		QuayOrganization: "redhat-user-workloads",
 	}).SetupWithManager(k8sManager)

--- a/pkg/logs/constants.go
+++ b/pkg/logs/constants.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+const (
+	Action = "action"
+	Audit  = "audit"
+)
+
+// Action type represents all possible value of 'action' log field.
+// For more details see https://github.com/redhat-appstudio/book/blob/main/ADR/0006-log-conventions.md
+type ActionLogValue string
+
+const (
+	ActionView   ActionLogValue = "VIEW"
+	ActionAdd    ActionLogValue = "ADD"
+	ActionUpdate ActionLogValue = "UPDATE"
+	ActionDelete ActionLogValue = "DELETE"
+)

--- a/pkg/quay/quay.go
+++ b/pkg/quay/quay.go
@@ -85,7 +85,7 @@ func (c *QuayClient) CreateRepository(r RepositoryRequest) (*Repository, error) 
 	data := &Repository{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshall response body: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 
 	if res.StatusCode == 400 && data.ErrorMessage == "Repository already exists" {
@@ -127,7 +127,7 @@ func (c *QuayClient) DeleteRepository(organization, imageRepository string) (boo
 	data := &QuayError{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		return false, fmt.Errorf("failed to unmarshall response body: %w", err)
+		return false, fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 	if data.Error != "" {
 		return false, errors.New(data.Error)
@@ -159,7 +159,7 @@ func (c *QuayClient) GetRobotAccount(organization string, robotName string) (*Ro
 	data := &RobotAccount{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshall response body: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 
 	if data.Message != "" {
@@ -199,7 +199,7 @@ func (c *QuayClient) CreateRobotAccount(organization string, robotName string) (
 	data := &RobotAccount{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshall response body: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 
 	if res.StatusCode == 400 && strings.Contains(data.Message, "Existing robot with name") {
@@ -246,7 +246,7 @@ func (c *QuayClient) DeleteRobotAccount(organization string, robotName string) (
 	data := &QuayError{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		return false, fmt.Errorf("failed to unmarshall response body: %w", err)
+		return false, fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 	if data.Error != "" {
 		return false, errors.New(data.Error)

--- a/pkg/quay/quay.go
+++ b/pkg/quay/quay.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 	"regexp"
 	"strings"
 )
@@ -30,9 +30,10 @@ import (
 type QuayService interface {
 	CreateRepository(r RepositoryRequest) (*Repository, error)
 	DeleteRepository(organization, imageRepository string) (bool, error)
+	GetRobotAccount(organization string, robotName string) (*RobotAccount, error)
 	CreateRobotAccount(organization string, robotName string) (*RobotAccount, error)
 	DeleteRobotAccount(organization string, robotName string) (bool, error)
-	AddPermissionsToRobotAccount(organization, imageRepository, robotAccountName string) error
+	AddWritePermissionsToRobotAccount(organization, imageRepository, robotAccountName string) error
 	GetAllRepositories(organization string) ([]Repository, error)
 	GetAllRobotAccounts(organization string) ([]RobotAccount, error)
 	GetTagsFromPage(organization, repository string, page int) ([]Tag, bool, error)
@@ -57,47 +58,41 @@ func NewQuayClient(c *http.Client, authToken, url string) QuayClient {
 
 // CreateRepository creates a new Quay.io image repository.
 func (c *QuayClient) CreateRepository(r RepositoryRequest) (*Repository, error) {
-
 	url := fmt.Sprintf("%s/%s", c.url, "repository")
 
 	b, err := json.Marshal(r)
 	if err != nil {
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal repository request data: %w", err)
 	}
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
-
 	if err != nil {
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("%s %s", "Bearer", c.AuthToken))
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to Do request: %w", err)
 	}
 	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	data := &Repository{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshall response body: %w", err)
 	}
 
 	if res.StatusCode == 400 && data.ErrorMessage == "Repository already exists" {
 		data.Name = r.Repository
+	} else if data.ErrorMessage != "" {
+		return data, errors.New(data.ErrorMessage)
 	}
-	fmt.Println(string(body))
 	return data, nil
 }
 
@@ -107,14 +102,14 @@ func (c *QuayClient) DeleteRepository(organization, imageRepository string) (boo
 
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("%s %s", "Bearer", c.AuthToken))
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to Do request: %w", err)
 	}
 	defer res.Body.Close()
 
@@ -127,17 +122,50 @@ func (c *QuayClient) DeleteRepository(organization, imageRepository string) (boo
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to read response body: %w", err)
 	}
 	data := &QuayError{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to unmarshall response body: %w", err)
 	}
 	if data.Error != "" {
 		return false, errors.New(data.Error)
 	}
 	return false, errors.New(data.ErrorMessage)
+}
+
+func (c *QuayClient) GetRobotAccount(organization string, robotName string) (*RobotAccount, error) {
+	url := fmt.Sprintf("%s/%s/%s/%s/%s", c.url, "organization", organization, "robots", robotName)
+
+	req, err := http.NewRequest(http.MethodGet, url, &bytes.Buffer{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("%s %s", "Bearer", c.AuthToken))
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Do request: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	data := &RobotAccount{}
+	err = json.Unmarshal(body, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall response body: %w", err)
+	}
+
+	if data.Message != "" {
+		return data, errors.New(data.Message)
+	}
+	return data, nil
 }
 
 // CreateRobotAccount creates a new Quay.io robot account in the organization.
@@ -148,68 +176,38 @@ func (c *QuayClient) CreateRobotAccount(organization string, robotName string) (
 	}
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", c.url, "organization", organization, "robots", robotName)
 
-	payload := strings.NewReader(`{
-  "description": "Robot account for AppStudio Component"
-}`)
+	payload := strings.NewReader(`{"description": "Robot account for AppStudio Component"}`)
 
 	req, err := http.NewRequest(http.MethodPut, url, payload)
 	if err != nil {
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("%s %s", "Bearer", c.AuthToken))
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to Do request: %w", err)
 	}
 	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	data := &RobotAccount{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		fmt.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshall response body: %w", err)
 	}
 
 	if res.StatusCode == 400 && strings.Contains(data.Message, "Existing robot with name") {
-		req, err = http.NewRequest(http.MethodGet, url, &bytes.Buffer{})
+		data, err = c.GetRobotAccount(organization, robotName)
 		if err != nil {
-			fmt.Println(err)
-			return nil, err
-		}
-		req.Header.Add("Authorization", fmt.Sprintf("%s %s", "Bearer", c.AuthToken))
-		req.Header.Add("Content-Type", "application/json")
-
-		res, err := c.httpClient.Do(req)
-		if err != nil {
-			fmt.Println(err)
-			return nil, err
-		}
-		defer res.Body.Close()
-
-		body, err := io.ReadAll(res.Body)
-		if err != nil {
-			fmt.Println(err)
-			return nil, err
-		}
-
-		data = &RobotAccount{}
-		err = json.Unmarshal(body, data)
-		if err != nil {
-			fmt.Println(err)
 			return nil, err
 		}
 	}
-	fmt.Println(string(body))
 	return data, nil
 }
 
@@ -223,14 +221,14 @@ func (c *QuayClient) DeleteRobotAccount(organization string, robotName string) (
 
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("%s %s", "Bearer", c.AuthToken))
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to Do request: %w", err)
 	}
 	defer res.Body.Close()
 
@@ -243,12 +241,12 @@ func (c *QuayClient) DeleteRobotAccount(organization string, robotName string) (
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to read response body: %w", err)
 	}
 	data := &QuayError{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to unmarshall response body: %w", err)
 	}
 	if data.Error != "" {
 		return false, errors.New(data.Error)
@@ -256,54 +254,59 @@ func (c *QuayClient) DeleteRobotAccount(organization string, robotName string) (
 	return false, errors.New(data.ErrorMessage)
 }
 
-// AddPermissionsToRobotAccount enables "robotAccountName" to "write" to "repository"
-func (c *QuayClient) AddPermissionsToRobotAccount(organization, imageRepository, robotAccountName string) error {
+// AddWritePermissionsToRobotAccount enables "robotAccountName" to "write" to "repository"
+func (c *QuayClient) AddWritePermissionsToRobotAccount(organization, imageRepository, robotAccountName string) error {
+	var robotAccountFullName string
+	if robotName, err := handleRobotName(robotAccountName); err == nil {
+		robotAccountFullName = organization + "+" + robotName
+	} else {
+		return err
+	}
 
-	// example,
 	// url := "https://quay.io/api/v1/repository/redhat-appstudio/test-repo-using-api/permissions/user/redhat-appstudio+createdbysbose"
+	url := fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", c.url, organization, imageRepository, robotAccountFullName)
 
-	url := fmt.Sprintf("%s/repository/%s/%s/permissions/user/%s", c.url, organization, imageRepository, robotAccountName)
-	fmt.Println(url)
-	payload := strings.NewReader(`{
-	"role": "write"
-  }`)
+	payload := strings.NewReader(`{"role": "write"}`)
 
 	req, err := http.NewRequest(http.MethodPut, url, payload)
-
 	if err != nil {
-		fmt.Println(err)
-		return err
+		return fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("%s %s", "Bearer", c.AuthToken))
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err := c.httpClient.Do(req)
-	fmt.Println(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to Do request: %w", err)
 	}
 	if res.StatusCode != 200 {
-		return fmt.Errorf("error adding permissions to the robot account, got status code %d", res.StatusCode)
+		var message string
+		defer res.Body.Close()
+		// Ignore read errors while getting returned by quay API error
+		if body, err := io.ReadAll(res.Body); err == nil {
+			data := &QuayError{}
+			if err := json.Unmarshal(body, data); err == nil {
+				if data.ErrorMessage != "" {
+					message = data.ErrorMessage
+				} else {
+					message = data.Error
+				}
+			}
+		}
+		return fmt.Errorf("failed to add write permissions to the robot account. Status code: %d, message: %s", res.StatusCode, message)
 	}
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-	fmt.Println(string(body))
 	return nil
 }
 
 // Returns all repositories of the DEFAULT_QUAY_ORG organization (used in e2e-tests)
 func (c *QuayClient) GetAllRepositories(organization string) ([]Repository, error) {
-	repo_url := fmt.Sprintf("%s/repository", c.url)
-	values := url.Values{}
+	url := fmt.Sprintf("%s/repository", c.url)
+
+	values := neturl.Values{}
 	values.Add("last_modified", "true")
 	values.Add("namespace", organization)
 
-	req, err := http.NewRequest(http.MethodGet, repo_url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new request, error: %s", err)
 	}
@@ -357,7 +360,7 @@ func (c *QuayClient) GetAllRobotAccounts(organization string) ([]RobotAccount, e
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new request, error: %s", err)
+		return nil, fmt.Errorf("failed to create new request: %w", err)
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.AuthToken))
@@ -365,16 +368,16 @@ func (c *QuayClient) GetAllRobotAccounts(organization string) ([]RobotAccount, e
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to Do request, error: %s", err)
+		return nil, fmt.Errorf("failed to Do request: %w", err)
 	}
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("error getting repositories, got status code %d", res.StatusCode)
+		return nil, fmt.Errorf("failed to get robot accounts. Status code: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body, error: %s", err)
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	type Response struct {
@@ -383,7 +386,7 @@ func (c *QuayClient) GetAllRobotAccounts(organization string) ([]RobotAccount, e
 	var response Response
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal body, error: %s", err)
+		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 	return response.Robots, nil
 }
@@ -415,7 +418,7 @@ func (c *QuayClient) GetTagsFromPage(organization, repository string, page int) 
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to create new request, error: %s", err)
+		return nil, false, fmt.Errorf("failed to create new request: %w", err)
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.AuthToken))
@@ -423,16 +426,16 @@ func (c *QuayClient) GetTagsFromPage(organization, repository string, page int) 
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to Do request, error: %s", err)
+		return nil, false, fmt.Errorf("failed to Do request: %w", err)
 	}
 	if res.StatusCode != 200 {
-		return nil, false, fmt.Errorf("error getting repositories, got status code %d", res.StatusCode)
+		return nil, false, fmt.Errorf("failed to get repository tags. Status code: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to read response body, error: %s", err)
+		return nil, false, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	var response struct {
@@ -442,7 +445,7 @@ func (c *QuayClient) GetTagsFromPage(organization, repository string, page int) 
 	}
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to unmarshal body, error: %s", err)
+		return nil, false, fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 	return response.Tags, response.HasAdditional, nil
 }
@@ -473,12 +476,12 @@ func (c *QuayClient) DeleteTag(organization, repository, tag string) (bool, erro
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return false, fmt.Errorf("failed to read response body, error: %s", err)
+		return false, fmt.Errorf("failed to read response body: %w", err)
 	}
 	data := &QuayError{}
 	err = json.Unmarshal(body, data)
 	if err != nil {
-		return false, fmt.Errorf("failed to unmarshal body, error: %s", err)
+		return false, fmt.Errorf("failed to unmarshal response body: %s", err)
 	}
 	if data.Error != "" {
 		return false, errors.New(data.Error)

--- a/pkg/quay/quay_debug_test.go
+++ b/pkg/quay/quay_debug_test.go
@@ -27,7 +27,7 @@ var (
 	quayApiUrl = "https://quay.io/api/v1"
 
 	quayOrgName          = "test-org"
-	quayImageRepoName    = "test-component-repo"
+	quayImageRepoName    = "namespace/application/component"
 	quayRobotAccountName = "test-robot-account"
 )
 
@@ -98,7 +98,7 @@ func TestAddPermissionsToRobotAccount(t *testing.T) {
 	}
 	quayClient := NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayToken, quayApiUrl)
 
-	err := quayClient.AddPermissionsToRobotAccount(quayOrgName, quayImageRepoName, quayRobotAccountName)
+	err := quayClient.AddWritePermissionsToRobotAccount(quayOrgName, quayImageRepoName, quayRobotAccountName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/quay/quay_test.go
+++ b/pkg/quay/quay_test.go
@@ -90,7 +90,7 @@ func TestQuayClient_AddPermissions(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://quay.io/api/v1").
-		Put("/repository/org/repository/permissions/user/robot").
+		Put("/repository/org/repository/permissions/user/org\\+robot").
 		Reply(200)
 
 	client := &http.Client{Transport: &http.Transport{}}
@@ -98,7 +98,7 @@ func TestQuayClient_AddPermissions(t *testing.T) {
 
 	quayClient := NewQuayClient(client, "authtoken", "https://quay.io/api/v1")
 
-	err := quayClient.AddPermissionsToRobotAccount("org", "repository", "robot")
+	err := quayClient.AddWritePermissionsToRobotAccount("org", "repository", "robot")
 
 	if err != nil {
 		t.Errorf("Error creating repository, Expected nil, got %v", err)


### PR DESCRIPTION
This PR makes Image Controller operator logs aligned with [ADR6](https://github.com/redhat-appstudio/book/blob/main/ADR/0006-log-conventions.md).
Now, by default, Image Controller prints logs in JSON format. Logs example in `json` format:

<details>
<summary>Show log in JSON format</summary>

```
{"level":"info","ts":"2023-04-27T08:23:24.959Z","logger":"setup","caller":"rest/request.go:538","msg":"Waited for 1.037392686s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/k8s.cni.cncf.io/v1?timeout=32s\n"}
{"level":"info","ts":"2023-04-27T08:23:27.168Z","logger":"controller-runtime.metrics","caller":"metrics/listener.go:44","msg":"Metrics server is starting to listen","addr":"127.0.0.1:8080"}
{"level":"info","ts":"2023-04-27T08:23:27.168Z","logger":"setup","caller":"runtime/proc.go:250","msg":"starting manager"}
{"level":"info","ts":"2023-04-27T08:23:27.169Z","caller":"runtime/asm_amd64.s:1571","msg":"Starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2023-04-27T08:23:27.169Z","caller":"runtime/asm_amd64.s:1571","msg":"Starting server","path":"/metrics","kind":"metrics","addr":"127.0.0.1:8080"}
{"level":"info","ts":"2023-04-27T08:23:27.169Z","logger":"setup","caller":"leaderelection/leaderelection.go:206","msg":"attempting to acquire leader lease image-controller/ed4c18c3.appstudio.redhat.com...\n"}
{"level":"info","ts":"2023-04-27T08:23:44.677Z","logger":"setup","caller":"wait/wait.go:155","msg":"successfully acquired lease image-controller/ed4c18c3.appstudio.redhat.com\n"}
{"level":"info","ts":"2023-04-27T08:23:44.677Z","caller":"controller/controller.go:241","msg":"Starting EventSource","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","source":"kind source: *v1alpha1.Component"}
{"level":"info","ts":"2023-04-27T08:23:44.677Z","caller":"controller/controller.go:241","msg":"Starting Controller","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component"}
{"level":"info","ts":"2023-04-27T08:23:44.779Z","caller":"controller/controller.go:241","msg":"Starting workers","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","worker count":1}
{"level":"info","ts":"2023-04-27T08:24:23.729Z","logger":"ComponentImageRepository","caller":"controller/controller.go:121","msg":"Waiting for devfile model in component","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","component":{"name":"go-component-sample","namespace":"test"},"namespace":"test","name":"go-component-sample","reconcileID":"11ab41f5-98cb-47b6-9473-66c2bb49c0fb"}
{"level":"info","ts":"2023-04-27T08:24:23.747Z","logger":"ComponentImageRepository","caller":"controller/controller.go:121","msg":"Waiting for devfile model in component","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","component":{"name":"go-component-sample","namespace":"test"},"namespace":"test","name":"go-component-sample","reconcileID":"d2cb01bc-a5f4-4fb7-b399-f743a18b219e"}
{"level":"info","ts":"2023-04-27T08:24:35.419Z","logger":"ComponentImageRepository","caller":"controller/controller.go:121","msg":"Created image registry secret go-component-sample for Component","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","component":{"name":"go-component-sample","namespace":"test"},"namespace":"test","name":"go-component-sample","reconcileID":"c6dfada3-7d0a-4e7f-a8c2-da18fafc90e5","action":"ADD"}
{"level":"info","ts":"2023-04-27T08:24:35.434Z","logger":"ComponentImageRepository","caller":"controller/controller.go:121","msg":"Image regipository finaliziler added to the Component","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","component":{"name":"go-component-sample","namespace":"test"},"namespace":"test","name":"go-component-sample","reconcileID":"c6dfada3-7d0a-4e7f-a8c2-da18fafc90e5","action":"UPDATE"}
{"level":"info","ts":"2023-04-27T08:24:35.434Z","logger":"ComponentImageRepository","caller":"controller/controller.go:121","msg":"Component updated successfully","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","component":{"name":"go-component-sample","namespace":"test"},"namespace":"test","name":"go-component-sample","reconcileID":"c6dfada3-7d0a-4e7f-a8c2-da18fafc90e5","action":"UPDATE"}
{"level":"info","ts":"2023-04-27T08:24:49.504Z","logger":"ComponentImageRepository","caller":"controller/controller.go:121","msg":"Deleted robot account testgo-application-samplego-component-sample","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","component":{"name":"go-component-sample","namespace":"test"},"namespace":"test","name":"go-component-sample","reconcileID":"be7149b8-7f7e-4f66-bad2-30da89029b37","action":"DELETE"}
{"level":"info","ts":"2023-04-27T08:24:50.171Z","logger":"ComponentImageRepository","caller":"controller/controller.go:121","msg":"Deleted image repository test/go-application-sample/go-component-sample","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","component":{"name":"go-component-sample","namespace":"test"},"namespace":"test","name":"go-component-sample","reconcileID":"be7149b8-7f7e-4f66-bad2-30da89029b37","action":"DELETE"}
{"level":"info","ts":"2023-04-27T08:24:50.193Z","logger":"ComponentImageRepository","caller":"controller/controller.go:121","msg":"Image repository finalizer removed from the Component","controller":"component","controllerGroup":"appstudio.redhat.com","controllerKind":"Component","component":{"name":"go-component-sample","namespace":"test"},"namespace":"test","name":"go-component-sample","reconcileID":"be7149b8-7f7e-4f66-bad2-30da89029b37","action":"DELETE"}
```

</details>