### PR TITLE
STONEBLD-29: Set slack notifacion on push fail

### DIFF
--- a/.tekton/merge-to-main.yaml
+++ b/.tekton/merge-to-main.yaml
@@ -17,6 +17,8 @@ spec:
     - name: infra-deployment-update-script
       value: |
         sed -i -e 's|\(https://github.com/redhat-appstudio/image-controller/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/image-controller/base/kustomization.yaml
+    - name: slack-webhook-notification-team
+      value: build
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest


### PR DESCRIPTION
When push fails then create slack notification on build team channel.