### PR TITLE
Prune sbom and attestation images from the registry

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+- ../registry_image_pruner
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/registry_image_pruner/cronjob.yaml
+++ b/config/registry_image_pruner/cronjob.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: image-pruner-cronjob
+spec:
+  schedule: "0 0 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: image-pruner
+            image: registry.redhat.io/rhel8/python-39:1-120.1684740828
+            env:
+              - name: QUAY_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: quaytoken
+                    key: quaytoken
+              - name: NAMESPACE
+                valueFrom:
+                  secretKeyRef:
+                    name: quaytoken
+                    key: organization
+            imagePullPolicy: IfNotPresent
+            command:
+              - /bin/bash
+              - '-c'
+              - >-
+                pip install -r /image-pruner/requirements.txt && python
+                /image-pruner/prune_images.py --namespace $(NAMESPACE)
+            volumeMounts:
+              - name: image-pruner-volume
+                mountPath: /image-pruner
+          restartPolicy: OnFailure
+          volumes:
+            - name: image-pruner-volume
+              configMap:
+                name: image-pruner-configmap
+            - name: quaytoken
+              secret:
+                secretName: quaytoken

--- a/config/registry_image_pruner/image_pruner/prune_images.py
+++ b/config/registry_image_pruner/image_pruner/prune_images.py
@@ -1,0 +1,94 @@
+import argparse
+import os
+import logging
+import re
+import requests
+
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO
+)
+LOGGER = logging.getLogger(__name__)
+QUAY_API_URL = "https://quay.io/api/v1"
+
+PROCESSED_REPOS = 0
+
+
+def remove_images(images, session, repository, dry_run=False):
+    image_digests = [image["manifest_digest"] for image in images.values()]
+    for image in images:
+        # attribute or sbom image
+        if image.endswith(".att") or image.endswith(".sbom"):
+            sha = re.search("sha256-(.*)(.sbom|.att)", image).group(1)
+            if f"sha256:{sha}" not in image_digests:
+                if dry_run:
+                    LOGGER.info("Image %s from %s should be removed", image, repository)
+                else:
+                    LOGGER.info("Removing image %s from %s", image, repository)
+                    delete_image_endpoint = (
+                        f"{QUAY_API_URL}/repository/{repository}/tag/{image}"
+                    )
+                    response = session.delete(delete_image_endpoint)
+                    response.raise_for_status()
+
+
+def process_repositories(repositories, session, dry_run=False):
+    global PROCESSED_REPOS
+
+    for repo in repositories:
+        repository = f"{repo['namespace']}/{repo['name']}"
+
+        PROCESSED_REPOS += 1
+        LOGGER.info("Processing repository %s: %s", PROCESSED_REPOS, repository)
+
+        repository_endpoint = f"{QUAY_API_URL}/repository/{repository}"
+        response = session.get(repository_endpoint)
+        response.raise_for_status()
+        repository_json = response.json()
+
+        images = repository_json.get("tags")
+        if images:
+            remove_images(images, session, repository, dry_run=dry_run)
+
+
+def main():
+    token = os.getenv("QUAY_TOKEN")
+    if not token:
+        raise ValueError("The token required for access to Quay API is missing!")
+
+    args = parse_args()
+
+    session = requests.Session()
+    session.headers = {"Authorization": f"Bearer {token}"}
+    session.params = {"namespace": args.namespace}
+    repositories_endpoint = f"{QUAY_API_URL}/repository"
+
+    response = session.get(repositories_endpoint)
+    response.raise_for_status()
+    resp_json = response.json()
+
+    repositories = resp_json.get("repositories")
+    next_page = resp_json.get("next_page")
+
+    if repositories:
+        process_repositories(repositories, session, dry_run=args.dry_run)
+
+    while next_page:
+        response = session.get(repositories_endpoint, params={"next_page": next_page})
+        response.raise_for_status()
+        resp_json = response.json()
+
+        repositories = resp_json.get("repositories")
+        next_page = resp_json.get("next_page")
+        process_repositories(repositories, session, dry_run=args.dry_run)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--namespace", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    main()

--- a/config/registry_image_pruner/image_pruner/requirements.txt
+++ b/config/registry_image_pruner/image_pruner/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/config/registry_image_pruner/image_pruner/tests/requirements.txt
+++ b/config/registry_image_pruner/image_pruner/tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+flexmock

--- a/config/registry_image_pruner/image_pruner/tests/test_prune_images.py
+++ b/config/registry_image_pruner/image_pruner/tests/test_prune_images.py
@@ -1,0 +1,146 @@
+import logging
+from flexmock import flexmock
+
+from prune_images import remove_images
+
+
+def test_remove_images(caplog):
+    images = {
+        "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att": {
+            "name": "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att",
+            "manifest_digest": "sha256:125c1d18ee1c3b9bde0c7810fcb0d4ffbc67e9b0c5b88bb8df9ca039bc1c9457",
+        },
+        "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom": {
+            "name": "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom",
+            "manifest_digest": "sha256:351326f899759a9a7ae3ca3c1cbdadcc8012f43231c145534820a68bdf36d55b",
+        },
+    }
+
+    session_mock = flexmock()
+    response_mock = flexmock()
+    response_mock.should_receive("raise_for_status").and_return(None)
+    session_mock.should_receive("delete").with_args(
+        "https://quay.io/api/v1/repository/some/repository/tag/sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att"
+    ).and_return(response_mock)
+    session_mock.should_receive("delete").with_args(
+        "https://quay.io/api/v1/repository/some/repository/tag/sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom"
+    ).and_return(response_mock)
+
+    with caplog.at_level(logging.INFO):
+        remove_images(images, session_mock, "some/repository", dry_run=False)
+    assert (
+        "Removing image sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att from some/repository"
+        in caplog.text
+    )
+    assert (
+        "Removing image sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom from some/repository"
+        in caplog.text
+    )
+
+
+def test_remove_images_dry_run(caplog):
+    images = {
+        "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att": {
+            "name": "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att",
+            "manifest_digest": "sha256:125c1d18ee1c3b9bde0c7810fcb0d4ffbc67e9b0c5b88bb8df9ca039bc1c9457",
+        },
+        "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom": {
+            "name": "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom",
+            "manifest_digest": "sha256:351326f899759a9a7ae3ca3c1cbdadcc8012f43231c145534820a68bdf36d55b",
+        },
+    }
+
+    session_mock = flexmock()
+    session_mock.should_receive("delete").never()
+    session_mock.should_receive("delete").never()
+
+    with caplog.at_level(logging.INFO):
+        remove_images(images, session_mock, "some/repository", dry_run=True)
+    assert (
+        "Image sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att from some/repository should be removed"
+        in caplog.text
+    )
+    assert (
+        "Image sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom from some/repository should be removed"
+        in caplog.text
+    )
+
+
+def test_remove_images_nothing_to_remove(caplog):
+    images = {
+        "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att": {
+            "name": "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att",
+            "manifest_digest": "sha256:125c1d18ee1c3b9bde0c7810fcb0d4ffbc67e9b0c5b88bb8df9ca039bc1c9457",
+        },
+        "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom": {
+            "name": "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom",
+            "manifest_digest": "sha256:351326f899759a9a7ae3ca3c1cbdadcc8012f43231c145534820a68bdf36d55b",
+        },
+        "app-image": {
+            "name": "app-image",
+            "manifest_digest": "sha256:502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd",
+        },
+    }
+
+    session_mock = flexmock()
+    session_mock.should_receive("delete").never()
+    session_mock.should_receive("delete").never()
+    with caplog.at_level(logging.INFO):
+        remove_images(images, session_mock, "some/repository", dry_run=False)
+    assert not caplog.text
+
+
+def test_remove_images_multiple_images(caplog):
+    images = {
+        "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att": {
+            "name": "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att",
+            "manifest_digest": "sha256:125c1d18ee1c3b9bde0c7810fcb0d4ffbc67e9b0c5b88bb8df9ca039bc1c9457",
+        },
+        "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom": {
+            "name": "sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom",
+            "manifest_digest": "sha256:351326f899759a9a7ae3ca3c1cbdadcc8012f43231c145534820a68bdf36d55b",
+        },
+        "sha256-5c55025c0cfc402b2a42f9d35b14a92b1ba203407d2a81aad7ea3eae1a3737d4.att": {
+            "name": "sha256-5c55025c0cfc402b2a42f9d35b14a92b1ba203407d2a81aad7ea3eae1a3737d4.att",
+            "manifest_digest": "sha256:5126ed26d60fffab5f82783af65b5a8e69da0820b723eea82a0eb71b0743c191",
+        },
+        "sha256-5c55025c0cfc402b2a42f9d35b14a92b1ba203407d2a81aad7ea3eae1a3737d4.sbom": {
+            "name": "sha256-5c55025c0cfc402b2a42f9d35b14a92b1ba203407d2a81aad7ea3eae1a3737d4.sbom",
+            "manifest_digest": "sha256:9b1f70d94117c63ee73d53688a3e4d412c1ba58d86b8e45845cce9b8dab44113",
+        },
+    }
+
+    session_mock = flexmock()
+    response_mock = flexmock()
+    response_mock.should_receive("raise_for_status").and_return(None)
+    session_mock.should_receive("delete").with_args(
+        "https://quay.io/api/v1/repository/some/repository/tag/sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att"
+    ).and_return(response_mock)
+    session_mock.should_receive("delete").with_args(
+        "https://quay.io/api/v1/repository/some/repository/tag/sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom"
+    ).and_return(response_mock)
+    session_mock.should_receive("delete").with_args(
+        "https://quay.io/api/v1/repository/some/repository/tag/sha256-5c55025c0cfc402b2a42f9d35b14a92b1ba203407d2a81aad7ea3eae1a3737d4.att"
+    ).and_return(response_mock)
+    session_mock.should_receive("delete").with_args(
+        "https://quay.io/api/v1/repository/some/repository/tag/sha256-5c55025c0cfc402b2a42f9d35b14a92b1ba203407d2a81aad7ea3eae1a3737d4.sbom"
+    ).and_return(response_mock)
+
+    with caplog.at_level(logging.INFO):
+        remove_images(images, session_mock, "some/repository", dry_run=False)
+    assert (
+        "Removing image sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.att from some/repository"
+        in caplog.text
+    )
+    assert (
+        "Removing image sha256-502c8c35e31459e8774f88e115d50d2ad33ba0e9dfd80429bc70ed4c1fd9e0cd.sbom from some/repository"
+        in caplog.text
+    )
+    assert (
+        "Removing image sha256-5c55025c0cfc402b2a42f9d35b14a92b1ba203407d2a81aad7ea3eae1a3737d4.att from some/repository"
+        in caplog.text
+    )
+    assert (
+        "Removing image sha256-5c55025c0cfc402b2a42f9d35b14a92b1ba203407d2a81aad7ea3eae1a3737d4.sbom from some/repository"
+        in caplog.text
+    )

--- a/config/registry_image_pruner/kustomization.yaml
+++ b/config/registry_image_pruner/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- cronjob.yaml
+
+configMapGenerator:
+- name: image-pruner-configmap
+  files:
+  - image_pruner/prune_images.py
+  - image_pruner/requirements.txt


### PR DESCRIPTION
If application image is removed from quay, we need to make sure that the associated sbom and attestation images are removed as well.

This is done with cronjob that will run python script that checks registry repositories via API.

[STONEBLD-1251](https://issues.redhat.com//browse/STONEBLD-1251)