### PR TITLE
Implement image repository visibility configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 [![codecov](https://codecov.io/gh/redhat-appstudio/image-controller/branch/main/graph/badge.svg)](https://codecov.io/gh/redhat-appstudio/image-controller)
 # The Image Controller for AppStudio
-The Image Controller for AppStudio helps set up container image repositories for AppStudio `Components`. 
+The Image Controller for AppStudio helps set up container image repositories for AppStudio `Components`.
 
 ## Try it!
 
 ### Installation
 
-1. Install the project on your cluster by running `make deploy`. 
+1. Install the project on your cluster by running `make deploy`.
 2. Set up the Quay.io token that would be used by the controller to setup image repositories under the `quay.io/redhat-user-workloads` organization.
 
 ```
@@ -24,7 +24,7 @@ type: Opaque
 
 ### Create a Component
 
-To request the controller to setup an image repository, annotate the `Component` with `image.redhat.com/generate: 'true'`.
+To request the controller to setup an image repository, annotate the `Component` with `image.redhat.com/generate: '{"visibility": "public"}'` or `image.redhat.com/generate: '{"visibility": "private"}'` depending on desired repository visibility.
 
 
 ```
@@ -32,7 +32,7 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: Component
 metadata:
   annotations:
-    image.redhat.com/generate: 'true'
+    image.redhat.com/generate: '{"visibility": "public"}'
   name: billing
   namespace: image-controller-system
 spec:
@@ -40,18 +40,32 @@ spec:
   componentName: billing
 ```
 
+The `image.redhat.com/generate` annotation will be deleted after processing. The visibility status will be shown in `visibility` field of `image.redhat.com/image` annotation.
+
+Also, it's possible to change the `visibility` of the repository after it's creation by setting the annotation again.
+
+---
+**NOTE**
+
+If your quay.io organization has free plan that does not allow setting repositories as private, then the error will be shown in `message` field of `image.redhat.com/image` annotation and the repository will remain public.
+In such case, the only way to have private repository is to create it with `private` visibility parameter. It would be possible to change it to `public` later, but not vice versa.
+
+---
+
 If `Component`'s auto-generated image repository should be deleted after component deletion, add `image.redhat.com/delete-image-repo` annotation to the `Component`.
 
-### Verify 
+### Verify
 
-The `Image controller` would create the necessary resources on Quay.io and write out the details of the same into the `Component` resource as an annotation, namely: 
+The `Image controller` would create the necessary resources on Quay.io and write out the details of the same into the `Component` resource as an annotation, namely:
 
 * The image repository URL.
+* The image repository visibility.
 * The name of the Kubernets `Secret` in which the robot account token was written out to.
 
 ```
 {
    "image":"quay.io/redhat-user-workloads/image-controller-system/city-transit/billing",
+   "visibility":"public",
    "secret":"billing",
 }
 ```
@@ -63,8 +77,7 @@ metadata:
   annotations:
     image.redhat.com/generate: 'false'
     image.redhat.com/image: >-
-      {"image":"quay.io/redhat-user-workloads/image-controller-system/city-transit/billing","secret":"billing"
-      }
+      {"image":"quay.io/redhat-user-workloads/image-controller-system/city-transit/billing","visibility":"public","secret":"billing"}
   name: billing
   namespace: image-controller-system
   resourceVersion: '86424'

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Also, it's possible to change the `visibility` of the repository after it's crea
 ---
 **NOTE**
 
-If your quay.io organization has free plan that does not allow setting repositories as private, then the error will be shown in `message` field of `image.redhat.com/image` annotation and the repository will remain public.
-In such case, the only way to have private repository is to create it with `private` visibility parameter. It would be possible to change it to `public` later, but not vice versa.
+Your quay.io organization plan should allow creation of private repositories.
+If your quay.io organization has free plan that does not allow setting repositories as private, then the error will be shown in `message` field of `image.redhat.com/image` annotation and the repository will not be created or will remain public.
 
 ---
 

--- a/controllers/component_image_controller_remote_test.go
+++ b/controllers/component_image_controller_remote_test.go
@@ -56,10 +56,10 @@ func TestGenerateRemoteImage(t *testing.T) {
 	quayClient := quay.NewQuayClient(client, quayToken, "https://quay.io/api/v1")
 
 	r := ComponentReconciler{
-		QuayClient:       &quayClient,
+		QuayClient:       quayClient,
 		QuayOrganization: "redhat-user-workloads",
 	}
-	createdRepository, createdRobotAccount, err := r.generateImageRepository(context.TODO(), &testComponent)
+	createdRepository, createdRobotAccount, err := r.generateImageRepository(context.TODO(), &testComponent, &GenerateRepositoryOpts{Visibility: "public"})
 
 	if err != nil {
 		t.Errorf("Error generating repository and setting up robot account, Expected nil, got %v", err)

--- a/controllers/component_image_controller_test.go
+++ b/controllers/component_image_controller_test.go
@@ -13,205 +13,255 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package controllers_test
+package controllers
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/h2non/gock"
-	appstudioredhatcomv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	"github.com/redhat-appstudio/image-controller/controllers"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/redhat-appstudio/image-controller/pkg/quay"
 )
 
 var _ = Describe("Component image controller", func() {
 
-	Context("Upon creation of Component", func() {
-		It("Should be annotated and Secret should be created", func() {
-			appComponent := &appstudioredhatcomv1alpha1.Component{
-				TypeMeta: v1.TypeMeta{
-					APIVersion: "appstudio.redhat.com/v1alpha1",
-					Kind:       "Component",
-				},
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "default",
-					Annotations: map[string]string{
-						"foo":                                   "bar",
-						controllers.GenerateImageAnnotationName: "true",
-						controllers.DeleteImageRepositoryAnnotationName: "true",
-					},
-				},
-				Spec: appstudioredhatcomv1alpha1.ComponentSpec{
-					ComponentName: "foo",
-					Application:   "bar",
-					Source: appstudioredhatcomv1alpha1.ComponentSource{
-						ComponentSourceUnion: appstudioredhatcomv1alpha1.ComponentSourceUnion{
-							GitSource: &appstudioredhatcomv1alpha1.GitSource{
-								URL: "github.com/foo/bar",
-							},
-						},
-					},
-				},
+	var (
+		resourceKey = types.NamespacedName{Name: defaultComponentName, Namespace: defaultComponentNamespace}
+	)
+
+	Context("Image repository provision flow", func() {
+
+		var (
+			token                    string
+			expectedRobotAccountName string
+			expectedRepoName         string
+			expectedImage            string
+		)
+
+		It("should prepare environment", func() {
+			ResetTestQuayClient()
+			createNamespace(defaultComponentNamespace)
+
+			token = "token1234"
+			expectedRobotAccountName = fmt.Sprintf("%s%s%s", defaultComponentNamespace, defaultComponentApplication, defaultComponentName)
+			expectedRepoName = fmt.Sprintf("%s/%s/%s", defaultComponentNamespace, defaultComponentApplication, defaultComponentName)
+			expectedImage = fmt.Sprintf("quay.io/%s/%s", testQuayOrg, expectedRepoName)
+		})
+
+		It("should do image repository provision", func() {
+
+			isCreateRepositoryInvoked := false
+			CreateRepositoryFunc = func(repository quay.RepositoryRequest) (*quay.Repository, error) {
+				isCreateRepositoryInvoked = true
+				Expect(repository.Repository).To(Equal(expectedRepoName))
+				Expect(repository.Namespace).To(Equal(testQuayOrg))
+				Expect(repository.Visibility).To(Equal("private"))
+				Expect(repository.Description).ToNot(BeEmpty())
+				return &quay.Repository{Name: expectedRepoName}, nil
+			}
+			isCreateRobotAccountInvoked := false
+			CreateRobotAccountFunc = func(organization, robotName string) (*quay.RobotAccount, error) {
+				isCreateRobotAccountInvoked = true
+				Expect(robotName).To(Equal(expectedRobotAccountName))
+				Expect(organization).To(Equal(testQuayOrg))
+				return &quay.RobotAccount{
+					Name:  expectedRobotAccountName,
+					Token: token,
+				}, nil
+			}
+			isAddWritePermissionsToRobotAccountInvoked := false
+			AddWritePermissionsToRobotAccountFunc = func(organization, imageRepository, robotAccountName string) error {
+				isAddWritePermissionsToRobotAccountInvoked = true
+				Expect(organization).To(Equal(testQuayOrg))
+				Expect(imageRepository).To(Equal(expectedRepoName))
+				Expect(robotAccountName).To(Equal(expectedRobotAccountName))
+				return nil
 			}
 
-			secretLookupKey := types.NamespacedName{Name: appComponent.Name, Namespace: appComponent.Namespace}
-
-			defer gock.Off()
-			defer gock.Observe(gock.DumpRequest)
-			gock.InterceptClient(httpClient)
-
-			// response from Repository API
-			quayOrganization := "redhat-user-workloads"
-			expectedRepoName := fmt.Sprintf("%s/%s/%s", appComponent.Namespace, appComponent.Spec.Application, appComponent.Name)
-
-			// request & response from Robot API
-			userProvidedRobotAccountName := appComponent.Namespace + appComponent.Spec.Application + appComponent.Name
-			returnedRobotAccountName := quayOrganization + "+" + userProvidedRobotAccountName
-			expectedToken := "token"
-
-			gock.New("https://quay.io").
-				Post("/api/v1/repository").
-				Reply(200).JSON(map[string]string{
-				"description": "description",
-				"namespace":   quayOrganization,
-				"name":        expectedRepoName,
+			createComponent(componentConfig{
+				ComponentKey: resourceKey,
+				Annotations: map[string]string{
+					GenerateImageAnnotationName:         "{\"visibility\": \"private\"}",
+					DeleteImageRepositoryAnnotationName: "true",
+				},
 			})
 
-			gock.New("https://quay.io").
-				Put(fmt.Sprintf("/api/v1/organization/%s/robots/%s", quayOrganization, userProvidedRobotAccountName)).
-				Reply(200).JSON(map[string]string{
-				"name":  returnedRobotAccountName,
-				"token": expectedToken,
+			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
+			Eventually(func() bool { return isCreateRobotAccountInvoked }, timeout, interval).Should(BeTrue())
+			Eventually(func() bool { return isAddWritePermissionsToRobotAccountInvoked }, timeout, interval).Should(BeTrue())
+
+			waitImageRepositoryFinalizerOnComponent(resourceKey)
+
+			waitComponentAnnotationGone(resourceKey, GenerateImageAnnotationName)
+			waitComponentAnnotation(resourceKey, ImageAnnotationName)
+
+			repoImageInfo := &ImageRepositoryStatus{}
+			component := getComponent(resourceKey)
+			Expect(json.Unmarshal([]byte(component.Annotations[ImageAnnotationName]), repoImageInfo)).To(Succeed())
+			Expect(repoImageInfo.Message).To(BeEmpty())
+			Expect(repoImageInfo.Image).To(Equal(expectedImage))
+			Expect(repoImageInfo.Visibility).To(Equal("private"))
+			Expect(repoImageInfo.Secret).To(Equal(resourceKey.Name))
+
+			waitSecretExist(resourceKey)
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, resourceKey, secret)).To(Succeed())
+			dockerconfigJson := string(secret.Data[corev1.DockerConfigJsonKey])
+			var authDataJson interface{}
+			Expect(json.Unmarshal([]byte(dockerconfigJson), &authDataJson)).To(Succeed())
+			Expect(dockerconfigJson).To(ContainSubstring(expectedImage))
+			Expect(dockerconfigJson).To(ContainSubstring(base64.StdEncoding.EncodeToString([]byte(token))))
+		})
+
+		It("should be able to switch image visibility", func() {
+			// TODO
+		})
+
+		It("should delete robot account and image repository on component deletion", func() {
+			CreateRepositoryFunc = func(repository quay.RepositoryRequest) (*quay.Repository, error) {
+				defer GinkgoRecover()
+				Fail("Should not invoke repository creation on clean up")
+				return nil, nil
+			}
+			CreateRobotAccountFunc = func(organization, robotName string) (*quay.RobotAccount, error) {
+				defer GinkgoRecover()
+				Fail("Should not invoke robot account creation on clean up")
+				return nil, nil
+			}
+			AddWritePermissionsToRobotAccountFunc = func(organization, imageRepository, robotAccountName string) error {
+				defer GinkgoRecover()
+				Fail("Should not invoke permission adding on clean up")
+				return nil
+			}
+
+			isDeleteRobotAccountInvoked := false
+			DeleteRobotAccountFunc = func(organization, robotAccountName string) (bool, error) {
+				isDeleteRobotAccountInvoked = true
+				Expect(organization).To(Equal(testQuayOrg))
+				Expect(robotAccountName).To(Equal(expectedRobotAccountName))
+				return true, nil
+			}
+			isDeleteRepositoryInvoked := false
+			DeleteRepositoryFunc = func(organization, imageRepository string) (bool, error) {
+				isDeleteRepositoryInvoked = true
+				Expect(organization).To(Equal(testQuayOrg))
+				Expect(imageRepository).To(Equal(expectedRepoName))
+				return true, nil
+			}
+
+			deleteComponent(resourceKey)
+
+			Eventually(func() bool { return isDeleteRobotAccountInvoked }, timeout, interval).Should(BeTrue())
+			Eventually(func() bool { return isDeleteRepositoryInvoked }, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("Image repository provision other cases", func() {
+
+		_ = BeforeEach(func() {
+			createNamespace(defaultComponentNamespace)
+
+			ResetTestQuayClient()
+		})
+
+		_ = AfterEach(func() {
+			deleteComponent(resourceKey)
+
+			deleteSecret(resourceKey)
+		})
+
+		It("should do nothing if generate annotation is not set", func() {
+			CreateRepositoryFunc = func(repository quay.RepositoryRequest) (*quay.Repository, error) {
+				defer GinkgoRecover()
+				Fail("Image repository creation should not be invoked")
+				return nil, nil
+			}
+
+			createComponent(componentConfig{ComponentKey: resourceKey})
+
+			time.Sleep(ensureTimeout)
+		})
+
+		It("should do nothing and set error if generate annotation is invalid JSON", func() {
+			CreateRepositoryFunc = func(repository quay.RepositoryRequest) (*quay.Repository, error) {
+				defer GinkgoRecover()
+				Fail("Image repository creation should not be invoked")
+				return nil, nil
+			}
+
+			createComponent(componentConfig{
+				ComponentKey: resourceKey,
+				Annotations: map[string]string{
+					GenerateImageAnnotationName: "{\"visibility\": \"public\"",
+				},
 			})
 
-			gock.New("https://quay.io").
-				Put(fmt.Sprintf("/api/v1/repository/redhat-user-workloads/default/bar/foo/permissions/user/%s", returnedRobotAccountName)).
-				Reply(200).JSON(map[string]string{})
+			waitComponentAnnotation(resourceKey, ImageAnnotationName)
 
-			Expect(k8sClient.Create(ctx, appComponent)).Should(BeNil())
-			hasCompLookupKey := types.NamespacedName{Name: appComponent.Name, Namespace: appComponent.Namespace}
-			createdHasComp := &appstudioredhatcomv1alpha1.Component{}
+			repoImageInfo := &ImageRepositoryStatus{}
+			component := getComponent(resourceKey)
+			Expect(json.Unmarshal([]byte(component.Annotations[ImageAnnotationName]), repoImageInfo)).To(Succeed())
+			Expect(repoImageInfo.Message).To(ContainSubstring("invalid JSON"))
 
-			Eventually(func() bool {
-				Expect(k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)).Should(Succeed())
-				return createdHasComp.ResourceVersion != ""
-			}).Should(BeTrue())
+		})
 
-			createdHasComp.Status.Devfile = "devfile"
-			Expect(k8sClient.Status().Update(context.Background(), createdHasComp)).Should(BeNil())
-			Eventually(func() bool {
-				Expect(k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)).Should(Succeed())
-				return createdHasComp.Status.Devfile == "devfile"
-			}).Should(BeTrue())
+		It("should do nothing and set error if generate annotation has invalid visibility value", func() {
+			CreateRepositoryFunc = func(repository quay.RepositoryRequest) (*quay.Repository, error) {
+				defer GinkgoRecover()
+				Fail("Image repository creation should not be invoked")
+				return nil, nil
+			}
 
-			Eventually(func() controllers.RepositoryInfo {
-				Expect(k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)).Should(Succeed())
-				annotations := createdHasComp.Annotations
-				imageRepo := annotations[controllers.ImageAnnotationName]
-
-				if imageRepo == "" {
-					// The controller may not finish the work to set the annotation yet.
-					// Return empty object for continuing wait
-					return controllers.RepositoryInfo{}
-				}
-
-				imageRepoObj := controllers.RepositoryInfo{}
-				Expect(json.Unmarshal([]byte(imageRepo), &imageRepoObj)).Should(Succeed())
-
-				return imageRepoObj
-			}).Should(Equal(controllers.RepositoryInfo{
-				Image:  "quay.io/redhat-user-workloads/default/bar/foo",
-				Secret: "foo",
-			}))
-
-			Eventually(func() string {
-				Expect(k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)).Should(BeNil())
-				annotations := createdHasComp.Annotations
-				return annotations["image.redhat.com/generate"]
-			}).Should(Equal("false"))
-
-			Eventually(func() string {
-				createdSecret := corev1.Secret{}
-				Expect(k8sClient.Get(context.Background(), secretLookupKey, &createdSecret)).Should(BeNil())
-				return string(createdSecret.Data[corev1.DockerConfigJsonKey][:])
-			}).Should(Equal(fmt.Sprintf(`{"auths":{"%s":{"auth":"%s"}}}`,
-				"quay.io/redhat-user-workloads/default/bar/foo",
-				base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", returnedRobotAccountName, expectedToken))))))
-
-			// Now that everything is verified, we shall try to regenerate the images.
-
-			gock.Clean()
-
-			// API Call to the Repository API should return a message that the Repository already exists
-			gock.New("https://quay.io").
-				Post("/api/v1/repository").
-				Reply(400).JSON(map[string]string{
-				"error_message": "Repository already exists",
+			createComponent(componentConfig{
+				ComponentKey: resourceKey,
+				Annotations: map[string]string{
+					GenerateImageAnnotationName: "{\"visibility\": \"none\"}",
+				},
 			})
 
-			// API Call to the Robot account API should return a message that the Robot account already exists
-			gock.New("https://quay.io").
-				Put(fmt.Sprintf("/api/v1/organization/%s/robots/%s", quayOrganization, userProvidedRobotAccountName)).
-				Reply(400).JSON(map[string]string{
-				"message": "Existing robot with name",
+			waitComponentAnnotation(resourceKey, ImageAnnotationName)
+
+			repoImageInfo := &ImageRepositoryStatus{}
+			component := getComponent(resourceKey)
+			Expect(json.Unmarshal([]byte(component.Annotations[ImageAnnotationName]), repoImageInfo)).To(Succeed())
+			Expect(repoImageInfo.Message).To(ContainSubstring("invalid value: none in visibility field"))
+		})
+
+		It("should accept deprecated true value for repository options", func() {
+			isCreateRepositoryInvoked := false
+			CreateRepositoryFunc = func(repository quay.RepositoryRequest) (*quay.Repository, error) {
+				isCreateRepositoryInvoked = true
+				return &quay.Repository{Name: "repo-name"}, nil
+			}
+
+			createComponent(componentConfig{
+				ComponentKey: resourceKey,
+				Annotations: map[string]string{
+					GenerateImageAnnotationName: "true",
+				},
 			})
-			// Should return existing Robot account
-			gock.New("https://quay.io").
-				Get(fmt.Sprintf("/api/v1/organization/%s/robots/%s", quayOrganization, userProvidedRobotAccountName)).
-				Reply(200).JSON(map[string]string{
-				"name":  returnedRobotAccountName,
-				"token": expectedToken,
-			})
 
-			// API Call to the Permissions API remains business as usual.
-			gock.New("https://quay.io").
-				Put(fmt.Sprintf("/api/v1/repository/redhat-user-workloads/default/bar/foo/permissions/user/%s", returnedRobotAccountName)).
-				Reply(200).JSON(map[string]string{})
+			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 
-			// trigger reconcile again.
-			createdHasComp.Annotations["image.redhat.com/generate"] = "true"
-			Expect(k8sClient.Update(ctx, createdHasComp)).Should(BeNil())
+			waitImageRepositoryFinalizerOnComponent(resourceKey)
 
-			Eventually(func() controllers.RepositoryInfo {
-				Expect(k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)).Should(Succeed())
-				annotations := createdHasComp.Annotations
-				imageRepo := annotations[controllers.ImageAnnotationName]
+			waitComponentAnnotationGone(resourceKey, GenerateImageAnnotationName)
+			waitComponentAnnotation(resourceKey, ImageAnnotationName)
 
-				imageRepoObj := controllers.RepositoryInfo{}
-				Expect(json.Unmarshal([]byte(imageRepo), &imageRepoObj)).Should(Succeed())
-
-				return imageRepoObj
-			}).Should(Equal(controllers.RepositoryInfo{
-				Image:  "quay.io/redhat-user-workloads/default/bar/foo",
-				Secret: "foo",
-			}))
-
-			// Check robot account deletion on Component deletion
-
-			gock.New("https://quay.io").
-				Delete(fmt.Sprintf("/api/v1/organization/%s/robots/%s", quayOrganization, userProvidedRobotAccountName)).
-				Reply(204).JSON(map[string]string{})
-
-			gock.New("https://quay.io").
-				Delete(fmt.Sprintf("/api/v1/repository/%s/%s", quayOrganization, expectedRepoName)).
-				Reply(204).JSON(map[string]string{})
-
-			Expect(k8sClient.Delete(ctx, appComponent)).To(Succeed())
-			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), hasCompLookupKey, createdHasComp)
-				return errors.IsNotFound(err)
-			}).Should(BeTrue())
+			repoImageInfo := &ImageRepositoryStatus{}
+			component := getComponent(resourceKey)
+			Expect(json.Unmarshal([]byte(component.Annotations[ImageAnnotationName]), repoImageInfo)).To(Succeed())
+			Expect(repoImageInfo.Message).To(BeEmpty())
+			Expect(repoImageInfo.Image).ToNot(BeEmpty())
+			Expect(repoImageInfo.Visibility).To(Equal("public"))
+			Expect(repoImageInfo.Secret).ToNot(BeEmpty())
 		})
 	})
 })

--- a/controllers/component_image_controller_unit_test.go
+++ b/controllers/component_image_controller_unit_test.go
@@ -29,45 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
-func TestShouldGenerateImage(t *testing.T) {
-	type args struct {
-		annotations map[string]string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "dont generate image repo",
-			args: args{
-				annotations: map[string]string{
-					"something-that-doesnt-matter": "",
-					GenerateImageAnnotationName:    "false",
-				},
-			},
-			want: false,
-		},
-		{
-			name: "generate image repo",
-			args: args{
-				annotations: map[string]string{
-					"something-that-doesnt-matter": "",
-					GenerateImageAnnotationName:    "true",
-				},
-			},
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldGenerateImage(tt.args.annotations); got != tt.want {
-				t.Errorf("name: %s, shouldGenerateImage() = %v, want %v", tt.name, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestGenerateImageRepository(t *testing.T) {
 	defer gock.Off()
 	defer gock.GetUnmatchedRequests()
@@ -122,10 +83,10 @@ func TestGenerateImageRepository(t *testing.T) {
 
 	quayClient := quay.NewQuayClient(client, "authtoken", "https://quay.io/api/v1")
 	r := ComponentReconciler{
-		QuayClient:       &quayClient,
+		QuayClient:       quayClient,
 		QuayOrganization: expectedNamespace,
 	}
-	createdRepository, createdRobotAccount, err := r.generateImageRepository(context.TODO(), &testComponent)
+	createdRepository, createdRobotAccount, err := r.generateImageRepository(context.TODO(), &testComponent, &GenerateRepositoryOpts{Visibility: "public"})
 
 	if err != nil {
 		t.Errorf("Error generating repository and setting up robot account, Expected nil, got %v", err)

--- a/controllers/suite_util_quay_client_test.go
+++ b/controllers/suite_util_quay_client_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import "github.com/redhat-appstudio/image-controller/pkg/quay"
+
+const (
+	testQuayOrg = "user-workloads"
+)
+
+// TestQuayClient is a QuayClient for testing the controller
+type TestQuayClient struct{}
+
+var _ quay.QuayService = (*TestQuayClient)(nil)
+
+var (
+	testQuayClient = &TestQuayClient{}
+
+	CreateRepositoryFunc                  func(repository quay.RepositoryRequest) (*quay.Repository, error)
+	DeleteRepositoryFunc                  func(organization, imageRepository string) (bool, error)
+	GetRobotAccountFunc                   func(organization string, robotName string) (*quay.RobotAccount, error)
+	CreateRobotAccountFunc                func(organization string, robotName string) (*quay.RobotAccount, error)
+	DeleteRobotAccountFunc                func(organization string, robotName string) (bool, error)
+	AddWritePermissionsToRobotAccountFunc func(organization, imageRepository, robotAccountName string) error
+)
+
+func ResetTestQuayClient() {
+	CreateRepositoryFunc = func(repository quay.RepositoryRequest) (*quay.Repository, error) { return &quay.Repository{}, nil }
+	DeleteRepositoryFunc = func(organization, imageRepository string) (bool, error) { return true, nil }
+	GetRobotAccountFunc = func(organization, robotName string) (*quay.RobotAccount, error) { return &quay.RobotAccount{}, nil }
+	CreateRobotAccountFunc = func(organization, robotName string) (*quay.RobotAccount, error) { return &quay.RobotAccount{}, nil }
+	DeleteRobotAccountFunc = func(organization, robotName string) (bool, error) { return true, nil }
+	AddWritePermissionsToRobotAccountFunc = func(organization, imageRepository, robotAccountName string) error { return nil }
+}
+
+func (c *TestQuayClient) CreateRepository(repositoryRequest quay.RepositoryRequest) (*quay.Repository, error) {
+	return CreateRepositoryFunc(repositoryRequest)
+}
+func (c *TestQuayClient) DeleteRepository(organization, imageRepository string) (bool, error) {
+	return DeleteRepositoryFunc(organization, imageRepository)
+}
+func (c *TestQuayClient) GetRobotAccount(organization string, robotName string) (*quay.RobotAccount, error) {
+	return GetRobotAccountFunc(organization, robotName)
+}
+func (c *TestQuayClient) CreateRobotAccount(organization string, robotName string) (*quay.RobotAccount, error) {
+	return CreateRobotAccountFunc(organization, robotName)
+}
+func (c *TestQuayClient) DeleteRobotAccount(organization string, robotName string) (bool, error) {
+	return DeleteRobotAccountFunc(organization, robotName)
+}
+func (c *TestQuayClient) AddWritePermissionsToRobotAccount(organization, imageRepository, robotAccountName string) error {
+	return AddWritePermissionsToRobotAccountFunc(organization, imageRepository, robotAccountName)
+}
+func (c *TestQuayClient) GetAllRepositories(organization string) ([]quay.Repository, error) {
+	return nil, nil
+}
+func (c *TestQuayClient) GetAllRobotAccounts(organization string) ([]quay.RobotAccount, error) {
+	return nil, nil
+}
+func (*TestQuayClient) DeleteTag(organization string, repository string, tag string) (bool, error) {
+	return true, nil
+}
+func (*TestQuayClient) GetTagsFromPage(organization string, repository string, page int) ([]quay.Tag, bool, error) {
+	return nil, false, nil
+}

--- a/controllers/suite_util_quay_client_test.go
+++ b/controllers/suite_util_quay_client_test.go
@@ -32,6 +32,7 @@ var (
 
 	CreateRepositoryFunc                  func(repository quay.RepositoryRequest) (*quay.Repository, error)
 	DeleteRepositoryFunc                  func(organization, imageRepository string) (bool, error)
+	ChangeRepositoryVisibilityFunc        func(organization, imageRepository string, visibility string) error
 	GetRobotAccountFunc                   func(organization string, robotName string) (*quay.RobotAccount, error)
 	CreateRobotAccountFunc                func(organization string, robotName string) (*quay.RobotAccount, error)
 	DeleteRobotAccountFunc                func(organization string, robotName string) (bool, error)
@@ -41,6 +42,7 @@ var (
 func ResetTestQuayClient() {
 	CreateRepositoryFunc = func(repository quay.RepositoryRequest) (*quay.Repository, error) { return &quay.Repository{}, nil }
 	DeleteRepositoryFunc = func(organization, imageRepository string) (bool, error) { return true, nil }
+	ChangeRepositoryVisibilityFunc = func(organization, imageRepository string, visibility string) error { return nil }
 	GetRobotAccountFunc = func(organization, robotName string) (*quay.RobotAccount, error) { return &quay.RobotAccount{}, nil }
 	CreateRobotAccountFunc = func(organization, robotName string) (*quay.RobotAccount, error) { return &quay.RobotAccount{}, nil }
 	DeleteRobotAccountFunc = func(organization, robotName string) (bool, error) { return true, nil }
@@ -52,6 +54,9 @@ func (c *TestQuayClient) CreateRepository(repositoryRequest quay.RepositoryReque
 }
 func (c *TestQuayClient) DeleteRepository(organization, imageRepository string) (bool, error) {
 	return DeleteRepositoryFunc(organization, imageRepository)
+}
+func (*TestQuayClient) ChangeRepositoryVisibility(organization, imageRepository string, visibility string) error {
+	return ChangeRepositoryVisibilityFunc(organization, imageRepository, visibility)
 }
 func (c *TestQuayClient) GetRobotAccount(organization string, robotName string) (*quay.RobotAccount, error) {
 	return GetRobotAccountFunc(organization, robotName)

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -229,6 +229,22 @@ func createNamespace(name string) {
 	}
 }
 
+func deleteNamespace(name string) {
+	namespace := corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := k8sClient.Delete(ctx, &namespace); err != nil && !k8sErrors.IsNotFound(err) {
+		Fail(err.Error())
+	}
+}
+
 func waitSecretExist(secretKey types.NamespacedName) *corev1.Secret {
 	secret := &corev1.Secret{}
 	Eventually(func() bool {

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	appstudioapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+)
+
+const (
+	// timeout is used as a limit until condition become true
+	// Usually used in Eventually statements
+	timeout = time.Second * 15
+	// ensureTimeout is used as a period of time during which the condition should not be changed
+	// Usually used in Consistently statements
+	ensureTimeout = time.Second * 4
+	interval      = time.Millisecond * 250
+)
+
+const (
+	defaultComponentName        = "test-component"
+	defaultComponentNamespace   = "test-namespace"
+	defaultComponentApplication = "test-application"
+)
+
+type componentConfig struct {
+	ComponentKey         types.NamespacedName
+	ComponentApplication string
+	Annotations          map[string]string
+}
+
+func getSampleComponentData(config componentConfig) *appstudioapiv1alpha1.Component {
+	name := config.ComponentKey.Name
+	if name == "" {
+		name = defaultComponentName
+	}
+	namespace := config.ComponentKey.Namespace
+	if namespace == "" {
+		namespace = defaultComponentNamespace
+	}
+	application := config.ComponentApplication
+	if application == "" {
+		application = defaultComponentApplication
+	}
+	annotations := make(map[string]string)
+	if config.Annotations != nil {
+		annotations = config.Annotations
+	}
+
+	return &appstudioapiv1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: appstudioapiv1alpha1.ComponentSpec{
+			ComponentName: name,
+			Application:   application,
+		},
+	}
+}
+
+// createComponent creates sample component resource and verifies it was properly created.
+// Sets devfile model, so the component can be processed right after creation.
+func createComponent(config componentConfig) *appstudioapiv1alpha1.Component {
+	component := getSampleComponentData(config)
+
+	Expect(k8sClient.Create(ctx, component)).Should(Succeed())
+	setComponentDevfileModel(config.ComponentKey)
+
+	componentKey := types.NamespacedName{Namespace: component.Namespace, Name: component.Name}
+	return getComponent(componentKey)
+}
+
+func getComponent(componentKey types.NamespacedName) *appstudioapiv1alpha1.Component {
+	component := &appstudioapiv1alpha1.Component{}
+	Eventually(func() bool {
+		Expect(k8sClient.Get(ctx, componentKey, component)).Should(Succeed())
+		return component.ResourceVersion != ""
+	}, timeout, interval).Should(BeTrue())
+	return component
+}
+
+// deleteComponent deletes the specified component resource and verifies it was properly deleted
+func deleteComponent(componentKey types.NamespacedName) {
+	component := &appstudioapiv1alpha1.Component{}
+
+	// Check if the component exists
+	if err := k8sClient.Get(ctx, componentKey, component); k8sErrors.IsNotFound(err) {
+		return
+	}
+
+	// Delete
+	Expect(k8sClient.Delete(ctx, component)).To(Succeed())
+
+	// Wait for delete to finish
+	Eventually(func() bool {
+		return k8sErrors.IsNotFound(k8sClient.Get(ctx, componentKey, component))
+	}, timeout, interval).Should(BeTrue())
+}
+
+func setComponentDevfile(componentKey types.NamespacedName, devfile string) {
+	component := &appstudioapiv1alpha1.Component{}
+	Eventually(func() error {
+		Expect(k8sClient.Get(ctx, componentKey, component)).To(Succeed())
+		component.Status.Devfile = devfile
+		return k8sClient.Status().Update(ctx, component)
+	}, timeout, interval).Should(Succeed())
+
+	component = getComponent(componentKey)
+	Expect(component.Status.Devfile).Should(Not(Equal("")))
+}
+
+func getMinimalDevfile() string {
+	return `
+        schemaVersion: 2.2.0
+        metadata:
+            name: minimal-devfile
+    `
+}
+
+func setComponentDevfileModel(componentKey types.NamespacedName) {
+	devfile := getMinimalDevfile()
+	setComponentDevfile(componentKey, devfile)
+}
+
+func setComponentAnnotationValue(componentKey types.NamespacedName, annotationName string, annotationValue string) {
+	component := getComponent(componentKey)
+	if component.Annotations == nil {
+		component.Annotations = make(map[string]string)
+	}
+	component.Annotations[annotationName] = annotationValue
+	Expect(k8sClient.Update(ctx, component)).To(Succeed())
+	waitComponentAnnotationValue(componentKey, annotationName, annotationValue)
+}
+
+func waitComponentAnnotation(componentKey types.NamespacedName, annotationName string) {
+	Eventually(func() bool {
+		component := getComponent(componentKey)
+		annotations := component.GetAnnotations()
+		if annotations == nil {
+			return false
+		}
+		_, exists := annotations[annotationName]
+		return exists
+	}, timeout, interval).Should(BeTrue())
+}
+
+func waitComponentAnnotationGone(componentKey types.NamespacedName, annotationName string) {
+	Eventually(func() bool {
+		component := getComponent(componentKey)
+		annotations := component.GetAnnotations()
+		if annotations == nil {
+			return true
+		}
+		_, exists := annotations[annotationName]
+		return !exists
+	}, timeout, interval).Should(BeTrue())
+}
+
+func waitComponentAnnotationValue(componentKey types.NamespacedName, annotationName string, annotationValue string) {
+	Eventually(func() bool {
+		component := getComponent(componentKey)
+		annotations := component.GetAnnotations()
+		return annotations != nil && annotations[annotationName] == annotationValue
+	}, timeout, interval).Should(BeTrue())
+}
+
+func waitFinalizerOnComponent(componentKey types.NamespacedName, finalizerName string, finalizerShouldBePresent bool) {
+	component := &appstudioapiv1alpha1.Component{}
+	Eventually(func() bool {
+		if err := k8sClient.Get(ctx, componentKey, component); err != nil {
+			return false
+		}
+
+		if finalizerShouldBePresent {
+			return controllerutil.ContainsFinalizer(component, finalizerName)
+		} else {
+			return !controllerutil.ContainsFinalizer(component, finalizerName)
+		}
+	}, timeout, interval).Should(BeTrue())
+}
+
+func waitImageRepositoryFinalizerOnComponent(componentKey types.NamespacedName) {
+	waitFinalizerOnComponent(componentKey, ImageRepositoryFinalizer, true)
+}
+
+func createNamespace(name string) {
+	namespace := corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := k8sClient.Create(ctx, &namespace); err != nil && !k8sErrors.IsAlreadyExists(err) {
+		Fail(err.Error())
+	}
+}
+
+func deleteNamespace(name string) {
+	namespace := corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := k8sClient.Delete(ctx, &namespace); err != nil && !k8sErrors.IsNotFound(err) {
+		Fail(err.Error())
+	}
+}
+
+func waitSecretExist(secretKey types.NamespacedName) *corev1.Secret {
+	secret := &corev1.Secret{}
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, secretKey, secret)
+		return err == nil && secret.ResourceVersion != ""
+	}, timeout, interval).Should(BeTrue())
+	return secret
+}
+
+func deleteSecret(resourceKey types.NamespacedName) {
+	secret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, resourceKey, secret); err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return
+		}
+		Fail(err.Error())
+	}
+	if err := k8sClient.Delete(ctx, secret); err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			Fail(err.Error())
+		}
+		return
+	}
+	Eventually(func() bool {
+		return k8sErrors.IsNotFound(k8sClient.Get(ctx, resourceKey, secret))
+	}, timeout, interval).Should(BeTrue())
+}

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -229,22 +229,6 @@ func createNamespace(name string) {
 	}
 }
 
-func deleteNamespace(name string) {
-	namespace := corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
-
-	if err := k8sClient.Delete(ctx, &namespace); err != nil && !k8sErrors.IsNotFound(err) {
-		Fail(err.Error())
-	}
-}
-
 func waitSecretExist(secretKey types.NamespacedName) *corev1.Secret {
 	secret := &corev1.Secret{}
 	Eventually(func() bool {

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -159,7 +159,6 @@ func setComponentAnnotationValue(componentKey types.NamespacedName, annotationNa
 	}
 	component.Annotations[annotationName] = annotationValue
 	Expect(k8sClient.Update(ctx, component)).To(Succeed())
-	waitComponentAnnotationValue(componentKey, annotationName, annotationValue)
 }
 
 func waitComponentAnnotation(componentKey types.NamespacedName, annotationName string) {
@@ -183,14 +182,6 @@ func waitComponentAnnotationGone(componentKey types.NamespacedName, annotationNa
 		}
 		_, exists := annotations[annotationName]
 		return !exists
-	}, timeout, interval).Should(BeTrue())
-}
-
-func waitComponentAnnotationValue(componentKey types.NamespacedName, annotationName string, annotationValue string) {
-	Eventually(func() bool {
-		component := getComponent(componentKey)
-		annotations := component.GetAnnotations()
-		return annotations != nil && annotations[annotationName] == annotationValue
 	}, timeout, interval).Should(BeTrue())
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,14 @@ go 1.18
 require (
 	github.com/go-logr/logr v1.2.3
 	github.com/h2non/gock v1.2.0
-	github.com/onsi/ginkgo v1.16.5
+	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.1
 	github.com/redhat-appstudio/application-api v0.0.0-20221220162402-c1e887791dac
+	go.uber.org/zap v1.19.1
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
+	k8s.io/klog/v2 v2.70.1
 	sigs.k8s.io/controller-runtime v0.12.2
 )
 
@@ -51,7 +53,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -60,7 +61,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
@@ -72,12 +72,10 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.24.3 // indirect
 	k8s.io/component-base v0.24.3 // indirect
-	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -176,7 +176,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -370,15 +369,14 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
-github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
+github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
@@ -689,7 +687,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -782,7 +779,6 @@ golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82u
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 	if err = (&controllers.ComponentReconciler{
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
-		QuayClient:       &quayClient,
+		QuayClient:       quayClient,
 		QuayOrganization: strings.TrimSpace(string(orgContent)),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Controller")

--- a/pkg/quay/quay.go
+++ b/pkg/quay/quay.go
@@ -28,7 +28,7 @@ import (
 )
 
 type QuayService interface {
-	CreateRepository(r RepositoryRequest) (*Repository, error)
+	CreateRepository(repositoryRequest RepositoryRequest) (*Repository, error)
 	DeleteRepository(organization, imageRepository string) (bool, error)
 	GetRobotAccount(organization string, robotName string) (*RobotAccount, error)
 	CreateRobotAccount(organization string, robotName string) (*RobotAccount, error)
@@ -48,8 +48,8 @@ type QuayClient struct {
 	AuthToken  string
 }
 
-func NewQuayClient(c *http.Client, authToken, url string) QuayClient {
-	return QuayClient{
+func NewQuayClient(c *http.Client, authToken, url string) *QuayClient {
+	return &QuayClient{
 		httpClient: c,
 		AuthToken:  authToken,
 		url:        url,
@@ -57,10 +57,10 @@ func NewQuayClient(c *http.Client, authToken, url string) QuayClient {
 }
 
 // CreateRepository creates a new Quay.io image repository.
-func (c *QuayClient) CreateRepository(r RepositoryRequest) (*Repository, error) {
+func (c *QuayClient) CreateRepository(repositoryRequest RepositoryRequest) (*Repository, error) {
 	url := fmt.Sprintf("%s/%s", c.url, "repository")
 
-	b, err := json.Marshal(r)
+	b, err := json.Marshal(repositoryRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal repository request data: %w", err)
 	}
@@ -89,7 +89,7 @@ func (c *QuayClient) CreateRepository(r RepositoryRequest) (*Repository, error) 
 	}
 
 	if res.StatusCode == 400 && data.ErrorMessage == "Repository already exists" {
-		data.Name = r.Repository
+		data.Name = repositoryRequest.Repository
 	} else if data.ErrorMessage != "" {
 		return data, errors.New(data.ErrorMessage)
 	}

--- a/pkg/quay/quay_debug_test.go
+++ b/pkg/quay/quay_debug_test.go
@@ -80,6 +80,20 @@ func TestDeleteRepository(t *testing.T) {
 	}
 }
 
+func TestChangeRepositoryVisibility(t *testing.T) {
+	if quayToken == "" {
+		return
+	}
+	visibility := "public"
+
+	quayClient := NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayToken, quayApiUrl)
+
+	err := quayClient.ChangeRepositoryVisibility(quayOrgName, quayImageRepoName, visibility)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCreateRobotAccount(t *testing.T) {
 	if quayToken == "" {
 		return


### PR DESCRIPTION
This PR allows to set image repository visibility via `image.redhat.com/generate` annotation.
The format of the annotation has been changed. Now it contains JSON and valid values are:
`image.redhat.com/generate: '{"visibility": "public"}` and `image.redhat.com/generate: '{"visibility": "private"}`.
Note, it's possible to set `private` visibility only if current quay organization plan allows that. Otherwise, error in `message` field of `image.redhat.com/image` annotation will be shown.

Old value `image.redhat.com/generate: "true"` is kept for backward compatibility with meaning of requesting public repository. Backward compatibility will be deleted after some time.