### PR TITLE
Always delete image repository with deletion of the component

### DIFF
--- a/controllers/component_image_controller_test.go
+++ b/controllers/component_image_controller_test.go
@@ -88,8 +88,7 @@ var _ = Describe("Component image controller", func() {
 			createComponent(componentConfig{
 				ComponentKey: resourceKey,
 				Annotations: map[string]string{
-					GenerateImageAnnotationName:         "{\"visibility\": \"private\"}",
-					DeleteImageRepositoryAnnotationName: "true",
+					GenerateImageAnnotationName: "{\"visibility\": \"private\"}",
 				},
 			})
 
@@ -359,8 +358,6 @@ var _ = Describe("Component image controller", func() {
 
 		It("should not block component deletion if clean up fails", func() {
 			waitImageRepositoryFinalizerOnComponent(resourceKey)
-
-			setComponentAnnotationValue(resourceKey, DeleteImageRepositoryAnnotationName, "true")
 
 			DeleteRepositoryFunc = func(organization, imageRepository string) (bool, error) {
 				return false, fmt.Errorf("failed to delete repository")


### PR DESCRIPTION
After this change, image controller operator will always delete component image repository on the component deletion.
Annotation `image.redhat.com/delete-image-repo` is deprecated and will have no effect.