### PR TITLE
ci: add required check for codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,10 +1,20 @@
 comment: off
 
+codecov:
+  require_ci_to_pass: no
+  notify: 
+    wait_for_ci: no
+
 coverage:
   status:
+    patch:
+      default:
+        informational: true
     project:
       default:
         target: auto
         threshold: 1%
         removed_code_behavior: adjust_base
-
+        if_ci_failed: success
+      required:
+        threshold: 2%


### PR DESCRIPTION
This PR configures codecov to be similar to codecov in build-service.
Please see https://github.com/redhat-appstudio/build-service/pull/176
and [STONEBLD-1439](https://issues.redhat.com/browse/STONEBLD-1439)