### PR TITLE
ci: fail codecov workflow if error happens

### DIFF
--- a/.github/workflows/codecov-main.yaml
+++ b/.github/workflows/codecov-main.yaml
@@ -17,3 +17,5 @@ jobs:
         run: make test
       - name: Upload Codecov Report
         uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true


### PR DESCRIPTION
Codecov upload on push to main is currently encountering an error, but the GitHub workflow does not fail like it does on pull request. 

This PR will make the worfklow fail if it encounters an error, making it easier to see the error