### PR TITLE
Add type to upload secret

### DIFF
--- a/controllers/component_image_controller.go
+++ b/controllers/component_image_controller.go
@@ -441,6 +441,7 @@ func (r *ComponentReconciler) createRemoteSecretUploadSecret(ctx context.Context
 				remotesecretv1beta1.RemoteSecretNameAnnotation: remoteSecretName,
 			},
 		},
+		Type:       corev1.SecretTypeDockerConfigJson,
 		StringData: generateDockerconfigSecretData(imageURL, robotAccount),
 	}
 	if err := r.Client.Create(ctx, uploadSecret); err != nil {

--- a/controllers/component_image_controller_test.go
+++ b/controllers/component_image_controller_test.go
@@ -178,6 +178,7 @@ var _ = Describe("Component image controller", func() {
 
 			Expect(uploadSecret.Labels[remotesecretv1beta1.UploadSecretLabel]).To(Equal("remotesecret"))
 			Expect(uploadSecret.Annotations[remotesecretv1beta1.RemoteSecretNameAnnotation]).To(Equal(remoteSecretKey.Name))
+			Expect(uploadSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
 
 			uploadSecretDockerconfigJson := string(uploadSecret.Data[corev1.DockerConfigJsonKey])
 			var authDataJson interface{}


### PR DESCRIPTION
A new validation [was added on RemoteSecret side](https://github.com/redhat-appstudio/remote-secret/pull/50) that requires to have the same secret type for both RemoteSecret and upload secret.
Add type to the upload secret to make RemoteSecret operator consume it.