### PR TITLE
Enable hermetic builds in RHTAP

### DIFF
--- a/.tekton/image-controller-pull-request.yaml
+++ b/.tekton/image-controller-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value: gomod
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/image-controller-push.yaml
+++ b/.tekton/image-controller-push.yaml
@@ -27,6 +27,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: 'true'
+  - name: prefetch-input
+    value: gomod
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
This configuration makes the pipeline execute an additional task to prefetch the build dependencies, and makes the container build be executed in complete network isolation.

Reference:
https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/proc_hermetic-builds
https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build/