### PR TITLE
test: Add test cases to pkg/quay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/redhat-appstudio/application-api v0.0.0-20221220162402-c1e887791dac
 	github.com/redhat-appstudio/remote-secret v0.0.0-20230711070755-b39d2b5f892e
 	go.uber.org/zap v1.24.0
+	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,7 @@ github.com/redhat-appstudio/remote-secret v0.0.0-20230711070755-b39d2b5f892e h1:
 github.com/redhat-appstudio/remote-secret v0.0.0-20230711070755-b39d2b5f892e/go.mod h1:QlcxNg0q63QFGr9ceI3dH7a7vO6gGh+2TJrbTiMf9DE=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
@@ -218,6 +219,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -271,6 +273,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.26.1 h1:f+SWYiPd/GsiWwVRz+NbFyCgvv75Pk9NK6dlkZgpCRQ=

--- a/pkg/quay/quay.go
+++ b/pkg/quay/quay.go
@@ -509,20 +509,13 @@ func (c *QuayClient) GetAllRobotAccounts(organization string) ([]RobotAccount, e
 // e.g. `org+robot` will be changed to `robot`, `robot` will stay `robot`
 func handleRobotName(robotName string) (string, error) {
 	// Regexp from quay api `^([a-z0-9]+(?:[._-][a-z0-9]+)*)$` with one plus sign in the middle allowed (representing longname)
-	r, err := regexp.Compile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:\+[a-z0-9]+(?:[._-][a-z0-9]+)*)?$`)
+	r := regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:\+[a-z0-9]+(?:[._-][a-z0-9]+)*)?$`)
 	robotName = strings.TrimSpace(robotName)
-	if err != nil {
-		return "", fmt.Errorf("failed to compile regex, error: %s", err)
-	}
 	if !r.MatchString(robotName) {
 		return "", fmt.Errorf("robot name is invalid, must match `^([a-z0-9]+(?:[._-][a-z0-9]+)*)$` (one plus sign in the middle is also allowed)")
 	}
 	if strings.Contains(robotName, "+") {
-		parts := strings.Split(robotName, "+")
-		if len(parts) != 2 {
-			return "", fmt.Errorf("robotName could not be split into two parts, expected len 2, got len %d", len(parts))
-		}
-		robotName = parts[1]
+		robotName = strings.Split(robotName, "+")[1]
 	}
 	return robotName, nil
 }


### PR DESCRIPTION
* Rewrite part of the test functions in order to add test cases conveniently.
* handleRobotName is refactored slightly. 1) Once the input robotName is matched, no need the check the number of parts separated by +. 2) The regexp is hardcoded and not an input from somewhere else, and the tests ensure that the regexp is correct and can be compiled by the library. So, no need to handle the err of an invalid regexp.
* Unify the type of response data passed to gock JSON func so that string value can be passed as well.
* Assertions are written with gotest.tools assert functions. One of the benefits is the error can be easily checked if it is nil and if a specific err is returned by specifying part of the error message.