### PR TITLE
feat: add "last_modified" to repository metadata

### DIFF
--- a/pkg/quay/api.go
+++ b/pkg/quay/api.go
@@ -17,6 +17,7 @@ type Repository struct {
 	IsOrganization bool           `json:"is_organization"`
 	IsStarred      bool           `json:"is_starred"`
 	IsPublic       bool           `json:"is_public"`
+	LastModified   int            `json:"last_modified"`
 	Name           string         `json:"name"`
 	Namespace      string         `json:"namespace"`
 	Image          string         `json:"image"`


### PR DESCRIPTION
this field is useful for the job that takes care of cleaning up old (and orphaned) repositories from the quay account