### PR TITLE
Fix kube-linter issues

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,6 +15,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          readOnlyRootFilesystem: true
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,6 +53,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/registry_image_pruner/cronjob.yaml
+++ b/config/registry_image_pruner/cronjob.yaml
@@ -33,7 +33,18 @@ spec:
             volumeMounts:
               - name: image-pruner-volume
                 mountPath: /image-pruner
+            resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 150m
+                memory: 128Mi
+            securityContext:
+              readOnlyRootFilesystem: true
           restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
           volumes:
             - name: image-pruner-volume
               configMap:


### PR DESCRIPTION
Fix kube-linter issues for controller-manager and image-pruner-cronjob pods/containers:

* Set runAsNonRoot and  readOnlyRootFilesystem to true.
* Set resources requests and limits.

[STONEBLD-1640](https://issues.redhat.com//browse/STONEBLD-1640)