### PR TITLE
Revert readOnlyRootFilesystem for image_pruner

### DIFF
--- a/config/registry_image_pruner/cronjob.yaml
+++ b/config/registry_image_pruner/cronjob.yaml
@@ -40,8 +40,6 @@ spec:
               requests:
                 cpu: 150m
                 memory: 128Mi
-            securityContext:
-              readOnlyRootFilesystem: true
           restartPolicy: OnFailure
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
The image-pruner container needs write on rootFS as it is installing pip packages. Put back write access until image-pruner is changed to not require this access.