### PR TITLE
Use Remote Secret for storing image repository push token

### DIFF
--- a/api/v1alpha1/imagerepository_types.go
+++ b/api/v1alpha1/imagerepository_types.go
@@ -108,7 +108,7 @@ type CredentialsStatus struct {
 
 	// PullSecretName is present only if ImageRepository has labels that connect it to Application and Component.
 	// Holds name of the dockerconfig secret with credentials to pull only from the generated repository.
-	// The secret is not present in the same namespace as ImageRepository, but created in
+	// The secret might not be present in the same namespace as ImageRepository, but created in other environments.
 	PullSecretName string `json:"pull-secret,omitempty"`
 
 	// PushRobotAccountName holds name of the quay robot account with write (push and pull) permissions into the generated repository.
@@ -117,6 +117,13 @@ type CredentialsStatus struct {
 	// PullRobotAccountName is present only if ImageRepository has labels that connect it to Application and Component.
 	// Holds name of the quay robot account with real (pull only) permissions from the generated repository.
 	PullRobotAccountName string `json:"pull-robot-account,omitempty"`
+
+	// PushRemoteSecretName holds name of RemoteSecret object that manages push Secret and its linking to appstudio-pipeline Service Account.
+	PushRemoteSecretName string `json:"push-remote-secret,omitempty"`
+
+	// PullRemoteSecretName is present only if ImageRepository has labels that connect it to Application and Component.
+	// Holds the name of the RemoteSecret object that manages pull Secret.
+	PullRemoteSecretName string `json:"pull-remote-secret,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/appstudio.redhat.com_imagerepositories.yaml
+++ b/config/crd/bases/appstudio.redhat.com_imagerepositories.yaml
@@ -82,6 +82,11 @@ spec:
                       were generated.
                     format: date-time
                     type: string
+                  pull-remote-secret:
+                    description: PullRemoteSecretName is present only if ImageRepository
+                      has labels that connect it to Application and Component. Holds
+                      the name of the RemoteSecret object that manages pull Secret.
+                    type: string
                   pull-robot-account:
                     description: PullRobotAccountName is present only if ImageRepository
                       has labels that connect it to Application and Component. Holds
@@ -92,8 +97,14 @@ spec:
                     description: PullSecretName is present only if ImageRepository
                       has labels that connect it to Application and Component. Holds
                       name of the dockerconfig secret with credentials to pull only
-                      from the generated repository. The secret is not present in
-                      the same namespace as ImageRepository, but created in
+                      from the generated repository. The secret might not be present
+                      in the same namespace as ImageRepository, but created in other
+                      environments.
+                    type: string
+                  push-remote-secret:
+                    description: PushRemoteSecretName holds name of RemoteSecret object
+                      that manages push Secret and its linking to appstudio-pipeline
+                      Service Account.
                     type: string
                   push-robot-account:
                     description: PushRobotAccountName holds name of the quay robot


### PR DESCRIPTION
This PRs makes push token stored in a RemoteSecret instead of just Secret. Such approach gives the following advantages:
* Ability to propagate the token to BYOC and remote clusters
* Makes Image Controller backup / restore friendly (avoiding backing up secrets directly)
* Simplifies self healing implementation
* Allows to have the same approach for push and pull tokens