### PR TITLE
Improve robot account already exists handling in quay client

### DIFF
--- a/pkg/quay/api.go
+++ b/pkg/quay/api.go
@@ -45,7 +45,9 @@ type RobotAccount struct {
 }
 
 // Quay API can sometimes return {"error": "..."} and sometimes {"error_message": "..."} without the field error
+// In some cases the error is send alongside the response in the {"message": "..."} field.
 type QuayError struct {
+	Message      string `json:"message,omitempty"`
 	Error        string `json:"error,omitempty"`
 	ErrorMessage string `json:"error_message,omitempty"`
 }

--- a/pkg/quay/quay_test.go
+++ b/pkg/quay/quay_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -202,11 +203,29 @@ func TestQuayClient_CreateRobotAccount(t *testing.T) {
 			expectedErr: "failed to create robot account",
 		},
 		{
-			name:       "robot account to be created already exists",
+			name:       "robot account to be created already exists, error in message field",
 			statusCode: 400,
 			responseData: map[string]string{
 				"name":    "robot",
 				"message": "Existing robot with name",
+			},
+			expectedErr: "",
+		},
+		{
+			name:       "robot account to be created already exists, error in error_message field",
+			statusCode: 400,
+			responseData: map[string]string{
+				"name":          "robot",
+				"error_message": "Existing robot with name",
+			},
+			expectedErr: "",
+		},
+		{
+			name:       "robot account to be created already exists, error in error field",
+			statusCode: 400,
+			responseData: map[string]string{
+				"name":  "robot",
+				"error": "Existing robot with name",
 			},
 			expectedErr: "",
 		},
@@ -230,7 +249,7 @@ func TestQuayClient_CreateRobotAccount(t *testing.T) {
 				req.AddMatcher(gock.MatchPath).Post("another-path")
 			}
 
-			if tc.name == "robot account to be created already exists" {
+			if strings.HasPrefix(tc.name, "robot account to be created already exists") {
 				gock.New(testQuayApiUrl).
 					MatchHeader("Content-Type", "application/json").
 					MatchHeader("Authorization", "Bearer authtoken").
@@ -260,7 +279,7 @@ func TestQuayClient_CreateRobotAccount(t *testing.T) {
 					assert.Equal(t, robotAcc.Token, "robotaccountoken")
 				}
 
-				if tc.name == "robot account to be created already exists" {
+				if strings.HasPrefix(tc.name, "robot account to be created already exists") {
 					// Ensure the returned robot account is got by calling GetRobotAccount func
 					assert.Equal(t, robotAcc.Token, "1234")
 				}


### PR DESCRIPTION
This PR improves handling of the situation when robot account already exists.
Quay might return error message in `message` or `error_message` or `error` filed of the response along with `400` status code.