### PR TITLE
Enable source image build

### DIFF
--- a/.tekton/image-controller-pull-request.yaml
+++ b/.tekton/image-controller-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: 'true'
   - name: prefetch-input
     value: gomod
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/image-controller-push.yaml
+++ b/.tekton/image-controller-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: 'true'
   - name: prefetch-input
     value: gomod
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
Enable source image build because it's now required by EC.