### PR TITLE
Pin to a non-breaking version of setup-envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
https://github.com/kubernetes-sigs/controller-runtime/issues/2720

The minimum required Go version for setup-envtes was bumped to 1.22, breaking us. Pin to release-0.16, which doesn't use 1.22 yet. It uses 1.21, which is still higher than what we use, but back then Go didn't enforce the version requirement yet.