### PR TITLE
chore: Update codecov version and add token

### DIFF
--- a/.github/workflows/codecov-main.yaml
+++ b/.github/workflows/codecov-main.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Run tests and collect coverage
         run: make test
       - name: Upload Codecov Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,8 +55,6 @@ jobs:
         run: make test
       - name: Upload codecov report
         uses: codecov/codecov-action@v3.1.1
-        with:
-          fail_ci_if_error: true
 
   test_prune_images:
     name: Run prune_images tests


### PR DESCRIPTION
codecov upload started failing due to the GH rate limiting. Have to use token while uploading as suggested [here](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954) , since we can only access the github secrets on push CI, so need to enable `fail_ci_if_error: false`