### PR TITLE
Remove devfile usage

### DIFF
--- a/controllers/component_image_controller.go
+++ b/controllers/component_image_controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/redhat-appstudio/image-controller/pkg/metrics"
 	"strings"
 	"time"
 
@@ -38,6 +37,7 @@ import (
 	"github.com/go-logr/logr"
 	appstudioredhatcomv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	l "github.com/redhat-appstudio/image-controller/pkg/logs"
+	"github.com/redhat-appstudio/image-controller/pkg/metrics"
 	"github.com/redhat-appstudio/image-controller/pkg/quay"
 	remotesecretv1beta1 "github.com/redhat-appstudio/remote-secret/api/v1beta1"
 )
@@ -170,16 +170,6 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	generateRepositoryOptsStr, exists := component.Annotations[GenerateImageAnnotationName]
 	if !exists {
 		// Nothing to do
-		return ctrl.Result{}, nil
-	}
-
-	// This is workaround for Application Service that doesn't properly handle component updates
-	// while initial operations with the Component are in progress.
-	if component.Status.Devfile == "" {
-		// The Component has been just created.
-		// Component controller (from Application Service) must set devfile model, wait for it.
-		log.Info("Waiting for devfile model in component")
-		// Do not requeue as after model update a new update event will trigger a new reconcile
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -167,12 +167,10 @@ func getSampleComponentData(config componentConfig) *appstudioapiv1alpha1.Compon
 }
 
 // createComponent creates sample component resource and verifies it was properly created.
-// Sets devfile model, so the component can be processed right after creation.
 func createComponent(config componentConfig) *appstudioapiv1alpha1.Component {
 	component := getSampleComponentData(config)
 
 	Expect(k8sClient.Create(ctx, component)).Should(Succeed())
-	setComponentDevfileModel(types.NamespacedName{Name: component.Name, Namespace: component.Namespace})
 
 	componentKey := types.NamespacedName{Namespace: component.Namespace, Name: component.Name}
 	return getComponent(componentKey)
@@ -203,31 +201,6 @@ func deleteComponent(componentKey types.NamespacedName) {
 	Eventually(func() bool {
 		return k8sErrors.IsNotFound(k8sClient.Get(ctx, componentKey, component))
 	}, timeout, interval).Should(BeTrue())
-}
-
-func setComponentDevfile(componentKey types.NamespacedName, devfile string) {
-	component := &appstudioapiv1alpha1.Component{}
-	Eventually(func() error {
-		Expect(k8sClient.Get(ctx, componentKey, component)).To(Succeed())
-		component.Status.Devfile = devfile
-		return k8sClient.Status().Update(ctx, component)
-	}, timeout, interval).Should(Succeed())
-
-	component = getComponent(componentKey)
-	Expect(component.Status.Devfile).Should(Not(Equal("")))
-}
-
-func getMinimalDevfile() string {
-	return `
-        schemaVersion: 2.2.0
-        metadata:
-            name: minimal-devfile
-    `
-}
-
-func setComponentDevfileModel(componentKey types.NamespacedName) {
-	devfile := getMinimalDevfile()
-	setComponentDevfile(componentKey, devfile)
 }
 
 func setComponentAnnotationValue(componentKey types.NamespacedName, annotationName string, annotationValue string) {


### PR DESCRIPTION
Image Controller was waiting for devfile to prevent errors in Application Service. Looks like the problem [is already fixed](https://github.com/redhat-appstudio/application-service/blob/main/controllers/component_controller_conditions.go#L53), so it's safe to remove this workaround from Image Controller.